### PR TITLE
Display name overrides

### DIFF
--- a/AudioSwitch.sln
+++ b/AudioSwitch.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2015
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioSwitch", "AudioSwitch.csproj", "{27E9D710-5098-4F59-8E81-412B63705301}"
 EndProject
 Global
@@ -16,15 +18,19 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|Any CPU.Build.0 = Debug|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|Win32.ActiveCfg = Debug|x86
+		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|Win32.Build.0 = Debug|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|x86.ActiveCfg = Debug|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Debug|x86.Build.0 = Debug|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Release|Any CPU.ActiveCfg = Release|x86
+		{27E9D710-5098-4F59-8E81-412B63705301}.Release|Any CPU.Build.0 = Release|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Release|Mixed Platforms.Build.0 = Release|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Release|Win32.ActiveCfg = Release|x86
+		{27E9D710-5098-4F59-8E81-412B63705301}.Release|Win32.Build.0 = Release|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Release|x86.ActiveCfg = Release|x86
 		{27E9D710-5098-4F59-8E81-412B63705301}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/Classes/Settings.cs
+++ b/Classes/Settings.cs
@@ -124,6 +124,9 @@ namespace AudioSwitch.Classes
 
             [XmlAttribute]
             public int Brightness;
+
+			[XmlAttribute]
+			public string DisplayName;
         }
 
         internal void Save()

--- a/Forms/FormSettings.Designer.cs
+++ b/Forms/FormSettings.Designer.cs
@@ -31,119 +31,613 @@ namespace AudioSwitch.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.tabSettings = new System.Windows.Forms.TabControl();
-            this.tabHotkeys = new System.Windows.Forms.TabPage();
-            this.gridHotkeys = new System.Windows.Forms.DataGridView();
-            this.Function = new System.Windows.Forms.DataGridViewComboBoxColumn();
-            this.Control = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.Alt = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.Shift = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.LWin = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.RWin = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.ShowOSD = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.HotKey = new System.Windows.Forms.DataGridViewComboBoxColumn();
-            this.tabDevices = new System.Windows.Forms.TabPage();
-            this.label2 = new System.Windows.Forms.Label();
-            this.groupDevice = new System.Windows.Forms.GroupBox();
-            this.label7 = new System.Windows.Forms.Label();
-            this.checkHideDevice = new System.Windows.Forms.CheckBox();
-            this.label9 = new System.Windows.Forms.Label();
-            this.label10 = new System.Windows.Forms.Label();
-            this.label11 = new System.Windows.Forms.Label();
-            this.buttonResetDevice = new System.Windows.Forms.Button();
-            this.buttonSaveDevice = new System.Windows.Forms.Button();
-            this.trackBrightness = new System.Windows.Forms.TrackBar();
-            this.trackSaturation = new System.Windows.Forms.TrackBar();
-            this.trackHue = new System.Windows.Forms.TrackBar();
-            this.pictureModded = new System.Windows.Forms.PictureBox();
-            this.listDevices = new AudioSwitch.Controls.CustomListView();
-            this.tabGeneral = new System.Windows.Forms.TabPage();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.checkQSShowOSD = new System.Windows.Forms.CheckBox();
-            this.radioQuickSwitch = new System.Windows.Forms.RadioButton();
-            this.radioAlwaysMenu = new System.Windows.Forms.RadioButton();
-            this.label5 = new System.Windows.Forms.Label();
-            this.checkShowHWName = new System.Windows.Forms.CheckBox();
-            this.checkColorVU = new System.Windows.Forms.CheckBox();
-            this.label6 = new System.Windows.Forms.Label();
-            this.comboDefMode = new System.Windows.Forms.ComboBox();
-            this.checkDefaultMultiAndComm = new System.Windows.Forms.CheckBox();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.checkVolScroll = new System.Windows.Forms.CheckBox();
-            this.checkScrShowOSD = new System.Windows.Forms.CheckBox();
-            this.comboScrollKey = new System.Windows.Forms.ComboBox();
-            this.labelVolScroll = new System.Windows.Forms.Label();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.labelAuthor = new System.Windows.Forms.Label();
-            this.linkWebpage = new System.Windows.Forms.LinkLabel();
-            this.labelVersion = new System.Windows.Forms.Label();
-            this.comboOSDSkin = new System.Windows.Forms.ComboBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.numTimeout = new System.Windows.Forms.NumericUpDown();
-            this.trackTransparency = new System.Windows.Forms.TrackBar();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label8 = new System.Windows.Forms.Label();
-            this.buttonClose = new System.Windows.Forms.Button();
-            this.label4 = new System.Windows.Forms.Label();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.labelTips = new System.Windows.Forms.Label();
-            this.tabSettings.SuspendLayout();
-            this.tabHotkeys.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gridHotkeys)).BeginInit();
-            this.tabDevices.SuspendLayout();
-            this.groupDevice.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackHue)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureModded)).BeginInit();
-            this.tabGeneral.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.groupBox4.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            this.groupBox3.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numTimeout)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackTransparency)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // tabSettings
-            // 
-            this.tabSettings.Controls.Add(this.tabGeneral);
-            this.tabSettings.Controls.Add(this.tabDevices);
-            this.tabSettings.Controls.Add(this.tabHotkeys);
-            this.tabSettings.HotTrack = true;
-            this.tabSettings.Location = new System.Drawing.Point(3, 4);
-            this.tabSettings.Name = "tabSettings";
-            this.tabSettings.SelectedIndex = 0;
-            this.tabSettings.Size = new System.Drawing.Size(540, 342);
-            this.tabSettings.TabIndex = 0;
-            // 
-            // tabHotkeys
-            // 
-            this.tabHotkeys.Controls.Add(this.gridHotkeys);
-            this.tabHotkeys.Location = new System.Drawing.Point(4, 22);
-            this.tabHotkeys.Name = "tabHotkeys";
-            this.tabHotkeys.Padding = new System.Windows.Forms.Padding(3);
-            this.tabHotkeys.Size = new System.Drawing.Size(532, 316);
-            this.tabHotkeys.TabIndex = 0;
-            this.tabHotkeys.Text = "Hot Keys";
-            this.tabHotkeys.UseVisualStyleBackColor = true;
-            this.tabHotkeys.Enter += new System.EventHandler(this.tabHotkeys_Enter);
-            // 
-            // gridHotkeys
-            // 
-            this.gridHotkeys.AllowUserToResizeColumns = false;
-            this.gridHotkeys.AllowUserToResizeRows = false;
-            this.gridHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+			this.tabSettings = new System.Windows.Forms.TabControl();
+			this.tabGeneral = new System.Windows.Forms.TabPage();
+			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.checkQSShowOSD = new System.Windows.Forms.CheckBox();
+			this.radioQuickSwitch = new System.Windows.Forms.RadioButton();
+			this.radioAlwaysMenu = new System.Windows.Forms.RadioButton();
+			this.label5 = new System.Windows.Forms.Label();
+			this.checkShowHWName = new System.Windows.Forms.CheckBox();
+			this.checkColorVU = new System.Windows.Forms.CheckBox();
+			this.label6 = new System.Windows.Forms.Label();
+			this.comboDefMode = new System.Windows.Forms.ComboBox();
+			this.checkDefaultMultiAndComm = new System.Windows.Forms.CheckBox();
+			this.groupBox4 = new System.Windows.Forms.GroupBox();
+			this.checkVolScroll = new System.Windows.Forms.CheckBox();
+			this.checkScrShowOSD = new System.Windows.Forms.CheckBox();
+			this.comboScrollKey = new System.Windows.Forms.ComboBox();
+			this.labelVolScroll = new System.Windows.Forms.Label();
+			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.groupBox3 = new System.Windows.Forms.GroupBox();
+			this.labelAuthor = new System.Windows.Forms.Label();
+			this.linkWebpage = new System.Windows.Forms.LinkLabel();
+			this.labelVersion = new System.Windows.Forms.Label();
+			this.comboOSDSkin = new System.Windows.Forms.ComboBox();
+			this.label1 = new System.Windows.Forms.Label();
+			this.numTimeout = new System.Windows.Forms.NumericUpDown();
+			this.trackTransparency = new System.Windows.Forms.TrackBar();
+			this.label3 = new System.Windows.Forms.Label();
+			this.label8 = new System.Windows.Forms.Label();
+			this.tabDevices = new System.Windows.Forms.TabPage();
+			this.label2 = new System.Windows.Forms.Label();
+			this.groupDevice = new System.Windows.Forms.GroupBox();
+			this.txtDisplayName = new System.Windows.Forms.TextBox();
+			this.label12 = new System.Windows.Forms.Label();
+			this.label7 = new System.Windows.Forms.Label();
+			this.checkHideDevice = new System.Windows.Forms.CheckBox();
+			this.label9 = new System.Windows.Forms.Label();
+			this.label10 = new System.Windows.Forms.Label();
+			this.label11 = new System.Windows.Forms.Label();
+			this.buttonResetDevice = new System.Windows.Forms.Button();
+			this.buttonSaveDevice = new System.Windows.Forms.Button();
+			this.trackBrightness = new System.Windows.Forms.TrackBar();
+			this.trackSaturation = new System.Windows.Forms.TrackBar();
+			this.trackHue = new System.Windows.Forms.TrackBar();
+			this.pictureModded = new System.Windows.Forms.PictureBox();
+			this.listDevices = new AudioSwitch.Controls.CustomListView();
+			this.tabHotkeys = new System.Windows.Forms.TabPage();
+			this.gridHotkeys = new System.Windows.Forms.DataGridView();
+			this.Function = new System.Windows.Forms.DataGridViewComboBoxColumn();
+			this.Control = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+			this.Alt = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+			this.Shift = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+			this.LWin = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+			this.RWin = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+			this.ShowOSD = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+			this.HotKey = new System.Windows.Forms.DataGridViewComboBoxColumn();
+			this.buttonClose = new System.Windows.Forms.Button();
+			this.label4 = new System.Windows.Forms.Label();
+			this.pictureBox1 = new System.Windows.Forms.PictureBox();
+			this.labelTips = new System.Windows.Forms.Label();
+			this.tabSettings.SuspendLayout();
+			this.tabGeneral.SuspendLayout();
+			this.groupBox2.SuspendLayout();
+			this.groupBox4.SuspendLayout();
+			this.groupBox1.SuspendLayout();
+			this.groupBox3.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numTimeout)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.trackTransparency)).BeginInit();
+			this.tabDevices.SuspendLayout();
+			this.groupDevice.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.trackHue)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.pictureModded)).BeginInit();
+			this.tabHotkeys.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.gridHotkeys)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// tabSettings
+			// 
+			this.tabSettings.Controls.Add(this.tabGeneral);
+			this.tabSettings.Controls.Add(this.tabDevices);
+			this.tabSettings.Controls.Add(this.tabHotkeys);
+			this.tabSettings.HotTrack = true;
+			this.tabSettings.Location = new System.Drawing.Point(3, 4);
+			this.tabSettings.Name = "tabSettings";
+			this.tabSettings.SelectedIndex = 0;
+			this.tabSettings.Size = new System.Drawing.Size(540, 342);
+			this.tabSettings.TabIndex = 0;
+			// 
+			// tabGeneral
+			// 
+			this.tabGeneral.Controls.Add(this.groupBox2);
+			this.tabGeneral.Controls.Add(this.groupBox4);
+			this.tabGeneral.Controls.Add(this.groupBox1);
+			this.tabGeneral.Location = new System.Drawing.Point(4, 22);
+			this.tabGeneral.Name = "tabGeneral";
+			this.tabGeneral.Size = new System.Drawing.Size(532, 316);
+			this.tabGeneral.TabIndex = 2;
+			this.tabGeneral.Text = "General";
+			this.tabGeneral.UseVisualStyleBackColor = true;
+			this.tabGeneral.Enter += new System.EventHandler(this.tabOSD_Enter);
+			this.tabGeneral.Leave += new System.EventHandler(this.tabOSD_Leave);
+			// 
+			// groupBox2
+			// 
+			this.groupBox2.Controls.Add(this.checkQSShowOSD);
+			this.groupBox2.Controls.Add(this.radioQuickSwitch);
+			this.groupBox2.Controls.Add(this.radioAlwaysMenu);
+			this.groupBox2.Controls.Add(this.label5);
+			this.groupBox2.Controls.Add(this.checkShowHWName);
+			this.groupBox2.Controls.Add(this.checkColorVU);
+			this.groupBox2.Controls.Add(this.label6);
+			this.groupBox2.Controls.Add(this.comboDefMode);
+			this.groupBox2.Controls.Add(this.checkDefaultMultiAndComm);
+			this.groupBox2.Location = new System.Drawing.Point(9, 194);
+			this.groupBox2.Name = "groupBox2";
+			this.groupBox2.Size = new System.Drawing.Size(510, 114);
+			this.groupBox2.TabIndex = 21;
+			this.groupBox2.TabStop = false;
+			this.groupBox2.Text = "General Behavior";
+			// 
+			// checkQSShowOSD
+			// 
+			this.checkQSShowOSD.AutoSize = true;
+			this.checkQSShowOSD.Location = new System.Drawing.Point(334, 90);
+			this.checkQSShowOSD.Name = "checkQSShowOSD";
+			this.checkQSShowOSD.Size = new System.Drawing.Size(79, 17);
+			this.checkQSShowOSD.TabIndex = 26;
+			this.checkQSShowOSD.Text = "Show OSD";
+			this.checkQSShowOSD.UseVisualStyleBackColor = true;
+			// 
+			// radioQuickSwitch
+			// 
+			this.radioQuickSwitch.Location = new System.Drawing.Point(315, 54);
+			this.radioQuickSwitch.Name = "radioQuickSwitch";
+			this.radioQuickSwitch.Size = new System.Drawing.Size(187, 33);
+			this.radioQuickSwitch.TabIndex = 24;
+			this.radioQuickSwitch.Text = "menu when AudioSwitch is open, otherwise quick-switches device";
+			this.radioQuickSwitch.UseVisualStyleBackColor = true;
+			this.radioQuickSwitch.CheckedChanged += new System.EventHandler(this.radioQuickSwitch_CheckedChanged);
+			// 
+			// radioAlwaysMenu
+			// 
+			this.radioAlwaysMenu.Checked = true;
+			this.radioAlwaysMenu.Location = new System.Drawing.Point(315, 34);
+			this.radioAlwaysMenu.Name = "radioAlwaysMenu";
+			this.radioAlwaysMenu.Size = new System.Drawing.Size(86, 17);
+			this.radioAlwaysMenu.TabIndex = 23;
+			this.radioAlwaysMenu.TabStop = true;
+			this.radioAlwaysMenu.Text = "always menu";
+			this.radioAlwaysMenu.UseVisualStyleBackColor = true;
+			// 
+			// label5
+			// 
+			this.label5.AutoSize = true;
+			this.label5.Location = new System.Drawing.Point(304, 16);
+			this.label5.Name = "label5";
+			this.label5.Size = new System.Drawing.Size(149, 13);
+			this.label5.TabIndex = 25;
+			this.label5.Text = "Right-clicking tray icon opens:";
+			// 
+			// checkShowHWName
+			// 
+			this.checkShowHWName.AutoSize = true;
+			this.checkShowHWName.Location = new System.Drawing.Point(14, 69);
+			this.checkShowHWName.Name = "checkShowHWName";
+			this.checkShowHWName.Size = new System.Drawing.Size(186, 17);
+			this.checkShowHWName.TabIndex = 22;
+			this.checkShowHWName.Text = "Show also device hardware name";
+			this.checkShowHWName.UseVisualStyleBackColor = true;
+			// 
+			// checkColorVU
+			// 
+			this.checkColorVU.Location = new System.Drawing.Point(14, 91);
+			this.checkColorVU.Name = "checkColorVU";
+			this.checkColorVU.Size = new System.Drawing.Size(121, 17);
+			this.checkColorVU.TabIndex = 21;
+			this.checkColorVU.Text = "Color LED VU meter";
+			this.checkColorVU.UseVisualStyleBackColor = true;
+			// 
+			// label6
+			// 
+			this.label6.Location = new System.Drawing.Point(11, 24);
+			this.label6.Name = "label6";
+			this.label6.Size = new System.Drawing.Size(108, 13);
+			this.label6.TabIndex = 18;
+			this.label6.Text = "Default GUI Devices:";
+			// 
+			// comboDefMode
+			// 
+			this.comboDefMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboDefMode.FormattingEnabled = true;
+			this.comboDefMode.Location = new System.Drawing.Point(125, 21);
+			this.comboDefMode.Name = "comboDefMode";
+			this.comboDefMode.Size = new System.Drawing.Size(121, 21);
+			this.comboDefMode.TabIndex = 19;
+			// 
+			// checkDefaultMultiAndComm
+			// 
+			this.checkDefaultMultiAndComm.Location = new System.Drawing.Point(14, 47);
+			this.checkDefaultMultiAndComm.Name = "checkDefaultMultiAndComm";
+			this.checkDefaultMultiAndComm.Size = new System.Drawing.Size(232, 17);
+			this.checkDefaultMultiAndComm.TabIndex = 20;
+			this.checkDefaultMultiAndComm.Text = "Switch also default communications device";
+			this.checkDefaultMultiAndComm.UseVisualStyleBackColor = true;
+			this.checkDefaultMultiAndComm.CheckedChanged += new System.EventHandler(this.checkDefaultMultiAndComm_CheckedChanged);
+			// 
+			// groupBox4
+			// 
+			this.groupBox4.Controls.Add(this.checkVolScroll);
+			this.groupBox4.Controls.Add(this.checkScrShowOSD);
+			this.groupBox4.Controls.Add(this.comboScrollKey);
+			this.groupBox4.Controls.Add(this.labelVolScroll);
+			this.groupBox4.Location = new System.Drawing.Point(9, 135);
+			this.groupBox4.Name = "groupBox4";
+			this.groupBox4.Size = new System.Drawing.Size(510, 53);
+			this.groupBox4.TabIndex = 8;
+			this.groupBox4.TabStop = false;
+			this.groupBox4.Text = "Volume Scrolling";
+			// 
+			// checkVolScroll
+			// 
+			this.checkVolScroll.Location = new System.Drawing.Point(14, 23);
+			this.checkVolScroll.Name = "checkVolScroll";
+			this.checkVolScroll.Size = new System.Drawing.Size(65, 17);
+			this.checkVolScroll.TabIndex = 22;
+			this.checkVolScroll.Text = "Enabled";
+			this.checkVolScroll.UseVisualStyleBackColor = true;
+			this.checkVolScroll.CheckedChanged += new System.EventHandler(this.checkVolScroll_CheckedChanged);
+			// 
+			// checkScrShowOSD
+			// 
+			this.checkScrShowOSD.Location = new System.Drawing.Point(390, 23);
+			this.checkScrShowOSD.Name = "checkScrShowOSD";
+			this.checkScrShowOSD.Size = new System.Drawing.Size(79, 17);
+			this.checkScrShowOSD.TabIndex = 8;
+			this.checkScrShowOSD.Text = "Show OSD";
+			this.checkScrShowOSD.UseVisualStyleBackColor = true;
+			this.checkScrShowOSD.CheckedChanged += new System.EventHandler(this.checkScrShowOSD_CheckedChanged);
+			// 
+			// comboScrollKey
+			// 
+			this.comboScrollKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboScrollKey.FormattingEnabled = true;
+			this.comboScrollKey.Items.AddRange(new object[] {
+            "LeftMouseButton",
+            "RightMouseButton",
+            "Control",
+            "Alt",
+            "LWin",
+            "RWin",
+            "Shift"});
+			this.comboScrollKey.Location = new System.Drawing.Point(85, 21);
+			this.comboScrollKey.Name = "comboScrollKey";
+			this.comboScrollKey.Size = new System.Drawing.Size(161, 21);
+			this.comboScrollKey.TabIndex = 21;
+			this.comboScrollKey.SelectedIndexChanged += new System.EventHandler(this.comboScrollKey_SelectedIndexChanged);
+			// 
+			// labelVolScroll
+			// 
+			this.labelVolScroll.Location = new System.Drawing.Point(245, 24);
+			this.labelVolScroll.Name = "labelVolScroll";
+			this.labelVolScroll.Size = new System.Drawing.Size(85, 13);
+			this.labelVolScroll.TabIndex = 23;
+			this.labelVolScroll.Text = " + Mouse Wheel";
+			// 
+			// groupBox1
+			// 
+			this.groupBox1.Controls.Add(this.groupBox3);
+			this.groupBox1.Controls.Add(this.numTimeout);
+			this.groupBox1.Controls.Add(this.trackTransparency);
+			this.groupBox1.Controls.Add(this.label3);
+			this.groupBox1.Controls.Add(this.label8);
+			this.groupBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+			this.groupBox1.Location = new System.Drawing.Point(9, 9);
+			this.groupBox1.Name = "groupBox1";
+			this.groupBox1.Size = new System.Drawing.Size(510, 120);
+			this.groupBox1.TabIndex = 18;
+			this.groupBox1.TabStop = false;
+			this.groupBox1.Text = "OSD Settings";
+			// 
+			// groupBox3
+			// 
+			this.groupBox3.Controls.Add(this.labelAuthor);
+			this.groupBox3.Controls.Add(this.linkWebpage);
+			this.groupBox3.Controls.Add(this.labelVersion);
+			this.groupBox3.Controls.Add(this.comboOSDSkin);
+			this.groupBox3.Controls.Add(this.label1);
+			this.groupBox3.Location = new System.Drawing.Point(8, 16);
+			this.groupBox3.Name = "groupBox3";
+			this.groupBox3.Size = new System.Drawing.Size(273, 99);
+			this.groupBox3.TabIndex = 8;
+			this.groupBox3.TabStop = false;
+			this.groupBox3.Text = "Skin";
+			// 
+			// labelAuthor
+			// 
+			this.labelAuthor.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+			this.labelAuthor.Location = new System.Drawing.Point(15, 47);
+			this.labelAuthor.Name = "labelAuthor";
+			this.labelAuthor.Size = new System.Drawing.Size(208, 13);
+			this.labelAuthor.TabIndex = 8;
+			this.labelAuthor.Text = "<Author>";
+			this.labelAuthor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// linkWebpage
+			// 
+			this.linkWebpage.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
+			this.linkWebpage.LinkColor = System.Drawing.SystemColors.HotTrack;
+			this.linkWebpage.Location = new System.Drawing.Point(15, 75);
+			this.linkWebpage.Name = "linkWebpage";
+			this.linkWebpage.Size = new System.Drawing.Size(208, 13);
+			this.linkWebpage.TabIndex = 15;
+			this.linkWebpage.TabStop = true;
+			this.linkWebpage.Text = "<Webpage>";
+			this.linkWebpage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			this.linkWebpage.VisitedLinkColor = System.Drawing.SystemColors.HotTrack;
+			this.linkWebpage.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkWebpage_LinkClicked);
+			// 
+			// labelVersion
+			// 
+			this.labelVersion.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+			this.labelVersion.Location = new System.Drawing.Point(54, 60);
+			this.labelVersion.Name = "labelVersion";
+			this.labelVersion.Size = new System.Drawing.Size(29, 12);
+			this.labelVersion.TabIndex = 16;
+			this.labelVersion.Text = "<ver>";
+			// 
+			// comboOSDSkin
+			// 
+			this.comboOSDSkin.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboOSDSkin.FormattingEnabled = true;
+			this.comboOSDSkin.Location = new System.Drawing.Point(18, 22);
+			this.comboOSDSkin.Name = "comboOSDSkin";
+			this.comboOSDSkin.Size = new System.Drawing.Size(205, 21);
+			this.comboOSDSkin.TabIndex = 12;
+			this.comboOSDSkin.SelectedIndexChanged += new System.EventHandler(this.comboOSDSkin_SelectedIndexChanged);
+			// 
+			// label1
+			// 
+			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+			this.label1.Location = new System.Drawing.Point(16, 60);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(37, 12);
+			this.label1.TabIndex = 8;
+			this.label1.Text = "Version";
+			// 
+			// numTimeout
+			// 
+			this.numTimeout.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.numTimeout.Location = new System.Drawing.Point(421, 79);
+			this.numTimeout.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+			this.numTimeout.Minimum = new decimal(new int[] {
+            500,
+            0,
+            0,
+            -2147483648});
+			this.numTimeout.Name = "numTimeout";
+			this.numTimeout.Size = new System.Drawing.Size(56, 20);
+			this.numTimeout.TabIndex = 10;
+			this.numTimeout.Value = new decimal(new int[] {
+            2000,
+            0,
+            0,
+            0});
+			this.numTimeout.ValueChanged += new System.EventHandler(this.numTimeout_ValueChanged);
+			// 
+			// trackTransparency
+			// 
+			this.trackTransparency.BackColor = System.Drawing.SystemColors.Window;
+			this.trackTransparency.Location = new System.Drawing.Point(317, 37);
+			this.trackTransparency.Maximum = 255;
+			this.trackTransparency.Name = "trackTransparency";
+			this.trackTransparency.Size = new System.Drawing.Size(160, 45);
+			this.trackTransparency.TabIndex = 14;
+			this.trackTransparency.Value = 255;
+			this.trackTransparency.Scroll += new System.EventHandler(this.trackTransparency_ValueChanged);
+			// 
+			// label3
+			// 
+			this.label3.Location = new System.Drawing.Point(308, 81);
+			this.label3.Name = "label3";
+			this.label3.Size = new System.Drawing.Size(107, 13);
+			this.label3.TabIndex = 11;
+			this.label3.Text = "Closing Timeout (ms):";
+			this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// label8
+			// 
+			this.label8.Location = new System.Drawing.Point(314, 17);
+			this.label8.Name = "label8";
+			this.label8.Size = new System.Drawing.Size(72, 13);
+			this.label8.TabIndex = 8;
+			this.label8.Text = "Transparency";
+			// 
+			// tabDevices
+			// 
+			this.tabDevices.Controls.Add(this.label2);
+			this.tabDevices.Controls.Add(this.groupDevice);
+			this.tabDevices.Controls.Add(this.listDevices);
+			this.tabDevices.Location = new System.Drawing.Point(4, 22);
+			this.tabDevices.Name = "tabDevices";
+			this.tabDevices.Padding = new System.Windows.Forms.Padding(3);
+			this.tabDevices.Size = new System.Drawing.Size(532, 316);
+			this.tabDevices.TabIndex = 1;
+			this.tabDevices.Text = "Devices";
+			this.tabDevices.UseVisualStyleBackColor = true;
+			this.tabDevices.Enter += new System.EventHandler(this.tabDevices_Enter);
+			// 
+			// label2
+			// 
+			this.label2.Location = new System.Drawing.Point(6, 6);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(101, 13);
+			this.label2.TabIndex = 8;
+			this.label2.Text = "Connected Devices";
+			// 
+			// groupDevice
+			// 
+			this.groupDevice.Controls.Add(this.txtDisplayName);
+			this.groupDevice.Controls.Add(this.label12);
+			this.groupDevice.Controls.Add(this.label7);
+			this.groupDevice.Controls.Add(this.checkHideDevice);
+			this.groupDevice.Controls.Add(this.label9);
+			this.groupDevice.Controls.Add(this.label10);
+			this.groupDevice.Controls.Add(this.label11);
+			this.groupDevice.Controls.Add(this.buttonResetDevice);
+			this.groupDevice.Controls.Add(this.buttonSaveDevice);
+			this.groupDevice.Controls.Add(this.trackBrightness);
+			this.groupDevice.Controls.Add(this.trackSaturation);
+			this.groupDevice.Controls.Add(this.trackHue);
+			this.groupDevice.Controls.Add(this.pictureModded);
+			this.groupDevice.Location = new System.Drawing.Point(268, 6);
+			this.groupDevice.Name = "groupDevice";
+			this.groupDevice.Size = new System.Drawing.Size(254, 304);
+			this.groupDevice.TabIndex = 8;
+			this.groupDevice.TabStop = false;
+			this.groupDevice.Text = "Selected Device Settings";
+			// 
+			// txtDisplayName
+			// 
+			this.txtDisplayName.Location = new System.Drawing.Point(88, 144);
+			this.txtDisplayName.Name = "txtDisplayName";
+			this.txtDisplayName.Size = new System.Drawing.Size(150, 20);
+			this.txtDisplayName.TabIndex = 28;
+			// 
+			// label12
+			// 
+			this.label12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.label12.Location = new System.Drawing.Point(13, 144);
+			this.label12.Name = "label12";
+			this.label12.Size = new System.Drawing.Size(80, 20);
+			this.label12.TabIndex = 27;
+			this.label12.Text = "Display Name";
+			this.label12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// label7
+			// 
+			this.label7.Location = new System.Drawing.Point(121, 27);
+			this.label7.Name = "label7";
+			this.label7.Size = new System.Drawing.Size(79, 13);
+			this.label7.TabIndex = 26;
+			this.label7.Text = "Tray Icon Color";
+			// 
+			// checkHideDevice
+			// 
+			this.checkHideDevice.Location = new System.Drawing.Point(17, 237);
+			this.checkHideDevice.Name = "checkHideDevice";
+			this.checkHideDevice.Size = new System.Drawing.Size(154, 17);
+			this.checkHideDevice.TabIndex = 25;
+			this.checkHideDevice.Text = "Hide device from switch list";
+			this.checkHideDevice.UseVisualStyleBackColor = true;
+			// 
+			// label9
+			// 
+			this.label9.Location = new System.Drawing.Point(42, 63);
+			this.label9.Name = "label9";
+			this.label9.Size = new System.Drawing.Size(27, 13);
+			this.label9.TabIndex = 16;
+			this.label9.Text = "Hue";
+			// 
+			// label10
+			// 
+			this.label10.Location = new System.Drawing.Point(14, 88);
+			this.label10.Name = "label10";
+			this.label10.Size = new System.Drawing.Size(55, 13);
+			this.label10.TabIndex = 19;
+			this.label10.Text = "Saturation";
+			// 
+			// label11
+			// 
+			this.label11.Location = new System.Drawing.Point(13, 114);
+			this.label11.Name = "label11";
+			this.label11.Size = new System.Drawing.Size(56, 13);
+			this.label11.TabIndex = 21;
+			this.label11.Text = "Brightness";
+			// 
+			// buttonResetDevice
+			// 
+			this.buttonResetDevice.Location = new System.Drawing.Point(16, 263);
+			this.buttonResetDevice.Name = "buttonResetDevice";
+			this.buttonResetDevice.Size = new System.Drawing.Size(102, 27);
+			this.buttonResetDevice.TabIndex = 13;
+			this.buttonResetDevice.Text = "Remove Settings";
+			this.buttonResetDevice.UseVisualStyleBackColor = true;
+			this.buttonResetDevice.Click += new System.EventHandler(this.buttonResetDevice_Click);
+			// 
+			// buttonSaveDevice
+			// 
+			this.buttonSaveDevice.Location = new System.Drawing.Point(137, 263);
+			this.buttonSaveDevice.Name = "buttonSaveDevice";
+			this.buttonSaveDevice.Size = new System.Drawing.Size(102, 27);
+			this.buttonSaveDevice.TabIndex = 18;
+			this.buttonSaveDevice.Text = "Save Settings";
+			this.buttonSaveDevice.UseVisualStyleBackColor = true;
+			this.buttonSaveDevice.Click += new System.EventHandler(this.buttonSaveDevice_Click);
+			// 
+			// trackBrightness
+			// 
+			this.trackBrightness.BackColor = System.Drawing.SystemColors.Window;
+			this.trackBrightness.Location = new System.Drawing.Point(88, 112);
+			this.trackBrightness.Maximum = 60;
+			this.trackBrightness.Name = "trackBrightness";
+			this.trackBrightness.Size = new System.Drawing.Size(151, 45);
+			this.trackBrightness.TabIndex = 24;
+			this.trackBrightness.TickStyle = System.Windows.Forms.TickStyle.None;
+			this.trackBrightness.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
+			// 
+			// trackSaturation
+			// 
+			this.trackSaturation.BackColor = System.Drawing.SystemColors.Window;
+			this.trackSaturation.Location = new System.Drawing.Point(88, 86);
+			this.trackSaturation.Maximum = 100;
+			this.trackSaturation.Name = "trackSaturation";
+			this.trackSaturation.Size = new System.Drawing.Size(151, 45);
+			this.trackSaturation.TabIndex = 23;
+			this.trackSaturation.TickStyle = System.Windows.Forms.TickStyle.None;
+			this.trackSaturation.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
+			// 
+			// trackHue
+			// 
+			this.trackHue.BackColor = System.Drawing.SystemColors.Window;
+			this.trackHue.Location = new System.Drawing.Point(88, 61);
+			this.trackHue.Maximum = 360;
+			this.trackHue.Name = "trackHue";
+			this.trackHue.Size = new System.Drawing.Size(151, 45);
+			this.trackHue.TabIndex = 22;
+			this.trackHue.TickStyle = System.Windows.Forms.TickStyle.None;
+			this.trackHue.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
+			// 
+			// pictureModded
+			// 
+			this.pictureModded.Location = new System.Drawing.Point(209, 19);
+			this.pictureModded.Name = "pictureModded";
+			this.pictureModded.Size = new System.Drawing.Size(30, 30);
+			this.pictureModded.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+			this.pictureModded.TabIndex = 20;
+			this.pictureModded.TabStop = false;
+			// 
+			// listDevices
+			// 
+			this.listDevices.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.listDevices.BackColor = System.Drawing.SystemColors.Window;
+			this.listDevices.BorderStyle = System.Windows.Forms.BorderStyle.None;
+			this.listDevices.FullRowSelect = true;
+			this.listDevices.HideSelection = false;
+			this.listDevices.Location = new System.Drawing.Point(6, 25);
+			this.listDevices.MultiSelect = false;
+			this.listDevices.Name = "listDevices";
+			this.listDevices.Size = new System.Drawing.Size(256, 285);
+			this.listDevices.TabIndex = 1;
+			this.listDevices.TileSize = new System.Drawing.Size(238, 40);
+			this.listDevices.UseCompatibleStateImageBehavior = false;
+			this.listDevices.View = System.Windows.Forms.View.Tile;
+			this.listDevices.SelectedIndexChanged += new System.EventHandler(this.listDevices_SelectedIndexChanged);
+			// 
+			// tabHotkeys
+			// 
+			this.tabHotkeys.Controls.Add(this.gridHotkeys);
+			this.tabHotkeys.Location = new System.Drawing.Point(4, 22);
+			this.tabHotkeys.Name = "tabHotkeys";
+			this.tabHotkeys.Padding = new System.Windows.Forms.Padding(3);
+			this.tabHotkeys.Size = new System.Drawing.Size(532, 316);
+			this.tabHotkeys.TabIndex = 0;
+			this.tabHotkeys.Text = "Hot Keys";
+			this.tabHotkeys.UseVisualStyleBackColor = true;
+			this.tabHotkeys.Enter += new System.EventHandler(this.tabHotkeys_Enter);
+			// 
+			// gridHotkeys
+			// 
+			this.gridHotkeys.AllowUserToResizeColumns = false;
+			this.gridHotkeys.AllowUserToResizeRows = false;
+			this.gridHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.gridHotkeys.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
-            this.gridHotkeys.BackgroundColor = System.Drawing.SystemColors.Window;
-            this.gridHotkeys.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.gridHotkeys.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.gridHotkeys.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+			this.gridHotkeys.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
+			this.gridHotkeys.BackgroundColor = System.Drawing.SystemColors.Window;
+			this.gridHotkeys.BorderStyle = System.Windows.Forms.BorderStyle.None;
+			this.gridHotkeys.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+			this.gridHotkeys.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Function,
             this.Control,
             this.Alt,
@@ -152,638 +646,165 @@ namespace AudioSwitch.Forms
             this.RWin,
             this.ShowOSD,
             this.HotKey});
-            this.gridHotkeys.GridColor = System.Drawing.SystemColors.Control;
-            this.gridHotkeys.Location = new System.Drawing.Point(6, 6);
-            this.gridHotkeys.Name = "gridHotkeys";
-            this.gridHotkeys.RowHeadersWidth = 25;
-            this.gridHotkeys.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            this.gridHotkeys.RowsDefaultCellStyle = dataGridViewCellStyle1;
-            this.gridHotkeys.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.gridHotkeys.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.gridHotkeys.Size = new System.Drawing.Size(520, 304);
-            this.gridHotkeys.TabIndex = 1;
-            // 
-            // Function
-            // 
-            this.Function.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Function.HeaderText = "Function";
-            this.Function.MaxDropDownItems = 100;
-            this.Function.MinimumWidth = 160;
-            this.Function.Name = "Function";
-            this.Function.Width = 160;
-            // 
-            // Control
-            // 
-            this.Control.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.Control.HeaderText = "Control";
-            this.Control.Name = "Control";
-            this.Control.Width = 46;
-            // 
-            // Alt
-            // 
-            this.Alt.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.Alt.HeaderText = "Alt";
-            this.Alt.Name = "Alt";
-            this.Alt.Width = 25;
-            // 
-            // Shift
-            // 
-            this.Shift.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.Shift.HeaderText = "Shift";
-            this.Shift.Name = "Shift";
-            this.Shift.Width = 34;
-            // 
-            // LWin
-            // 
-            this.LWin.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.LWin.HeaderText = "LWin";
-            this.LWin.Name = "LWin";
-            this.LWin.Width = 38;
-            // 
-            // RWin
-            // 
-            this.RWin.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.RWin.HeaderText = "RWin";
-            this.RWin.Name = "RWin";
-            this.RWin.Width = 40;
-            // 
-            // ShowOSD
-            // 
-            this.ShowOSD.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.ShowOSD.HeaderText = "Show OSD";
-            this.ShowOSD.Name = "ShowOSD";
-            this.ShowOSD.Width = 66;
-            // 
-            // HotKey
-            // 
-            this.HotKey.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.HotKey.HeaderText = "Hot Key";
-            this.HotKey.MaxDropDownItems = 20;
-            this.HotKey.MinimumWidth = 80;
-            this.HotKey.Name = "HotKey";
-            // 
-            // tabDevices
-            // 
-            this.tabDevices.Controls.Add(this.label2);
-            this.tabDevices.Controls.Add(this.groupDevice);
-            this.tabDevices.Controls.Add(this.listDevices);
-            this.tabDevices.Location = new System.Drawing.Point(4, 22);
-            this.tabDevices.Name = "tabDevices";
-            this.tabDevices.Padding = new System.Windows.Forms.Padding(3);
-            this.tabDevices.Size = new System.Drawing.Size(532, 316);
-            this.tabDevices.TabIndex = 1;
-            this.tabDevices.Text = "Devices";
-            this.tabDevices.UseVisualStyleBackColor = true;
-            this.tabDevices.Enter += new System.EventHandler(this.tabDevices_Enter);
-            // 
-            // label2
-            // 
-            this.label2.Location = new System.Drawing.Point(6, 6);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(101, 13);
-            this.label2.TabIndex = 8;
-            this.label2.Text = "Connected Devices";
-            // 
-            // groupDevice
-            // 
-            this.groupDevice.Controls.Add(this.label7);
-            this.groupDevice.Controls.Add(this.checkHideDevice);
-            this.groupDevice.Controls.Add(this.label9);
-            this.groupDevice.Controls.Add(this.label10);
-            this.groupDevice.Controls.Add(this.label11);
-            this.groupDevice.Controls.Add(this.buttonResetDevice);
-            this.groupDevice.Controls.Add(this.buttonSaveDevice);
-            this.groupDevice.Controls.Add(this.trackBrightness);
-            this.groupDevice.Controls.Add(this.trackSaturation);
-            this.groupDevice.Controls.Add(this.trackHue);
-            this.groupDevice.Controls.Add(this.pictureModded);
-            this.groupDevice.Location = new System.Drawing.Point(268, 6);
-            this.groupDevice.Name = "groupDevice";
-            this.groupDevice.Size = new System.Drawing.Size(254, 304);
-            this.groupDevice.TabIndex = 8;
-            this.groupDevice.TabStop = false;
-            this.groupDevice.Text = "Selected Device Settings";
-            // 
-            // label7
-            // 
-            this.label7.Location = new System.Drawing.Point(121, 27);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(79, 13);
-            this.label7.TabIndex = 26;
-            this.label7.Text = "Tray Icon Color";
-            // 
-            // checkHideDevice
-            // 
-            this.checkHideDevice.Location = new System.Drawing.Point(17, 237);
-            this.checkHideDevice.Name = "checkHideDevice";
-            this.checkHideDevice.Size = new System.Drawing.Size(154, 17);
-            this.checkHideDevice.TabIndex = 25;
-            this.checkHideDevice.Text = "Hide device from switch list";
-            this.checkHideDevice.UseVisualStyleBackColor = true;
-            // 
-            // label9
-            // 
-            this.label9.Location = new System.Drawing.Point(42, 63);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(27, 13);
-            this.label9.TabIndex = 16;
-            this.label9.Text = "Hue";
-            // 
-            // label10
-            // 
-            this.label10.Location = new System.Drawing.Point(14, 88);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(55, 13);
-            this.label10.TabIndex = 19;
-            this.label10.Text = "Saturation";
-            // 
-            // label11
-            // 
-            this.label11.Location = new System.Drawing.Point(13, 114);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(56, 13);
-            this.label11.TabIndex = 21;
-            this.label11.Text = "Brightness";
-            // 
-            // buttonResetDevice
-            // 
-            this.buttonResetDevice.Location = new System.Drawing.Point(16, 263);
-            this.buttonResetDevice.Name = "buttonResetDevice";
-            this.buttonResetDevice.Size = new System.Drawing.Size(102, 27);
-            this.buttonResetDevice.TabIndex = 13;
-            this.buttonResetDevice.Text = "Remove Settings";
-            this.buttonResetDevice.UseVisualStyleBackColor = true;
-            this.buttonResetDevice.Click += new System.EventHandler(this.buttonResetDevice_Click);
-            // 
-            // buttonSaveDevice
-            // 
-            this.buttonSaveDevice.Location = new System.Drawing.Point(137, 263);
-            this.buttonSaveDevice.Name = "buttonSaveDevice";
-            this.buttonSaveDevice.Size = new System.Drawing.Size(102, 27);
-            this.buttonSaveDevice.TabIndex = 18;
-            this.buttonSaveDevice.Text = "Save Settings";
-            this.buttonSaveDevice.UseVisualStyleBackColor = true;
-            this.buttonSaveDevice.Click += new System.EventHandler(this.buttonSaveDevice_Click);
-            // 
-            // trackBrightness
-            // 
-            this.trackBrightness.BackColor = System.Drawing.SystemColors.Window;
-            this.trackBrightness.Location = new System.Drawing.Point(75, 112);
-            this.trackBrightness.Maximum = 60;
-            this.trackBrightness.Name = "trackBrightness";
-            this.trackBrightness.Size = new System.Drawing.Size(164, 45);
-            this.trackBrightness.TabIndex = 24;
-            this.trackBrightness.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.trackBrightness.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
-            // 
-            // trackSaturation
-            // 
-            this.trackSaturation.BackColor = System.Drawing.SystemColors.Window;
-            this.trackSaturation.Location = new System.Drawing.Point(75, 86);
-            this.trackSaturation.Maximum = 100;
-            this.trackSaturation.Name = "trackSaturation";
-            this.trackSaturation.Size = new System.Drawing.Size(164, 45);
-            this.trackSaturation.TabIndex = 23;
-            this.trackSaturation.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.trackSaturation.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
-            // 
-            // trackHue
-            // 
-            this.trackHue.BackColor = System.Drawing.SystemColors.Window;
-            this.trackHue.Location = new System.Drawing.Point(75, 61);
-            this.trackHue.Maximum = 360;
-            this.trackHue.Name = "trackHue";
-            this.trackHue.Size = new System.Drawing.Size(164, 45);
-            this.trackHue.TabIndex = 22;
-            this.trackHue.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.trackHue.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
-            // 
-            // pictureModded
-            // 
-            this.pictureModded.Location = new System.Drawing.Point(209, 19);
-            this.pictureModded.Name = "pictureModded";
-            this.pictureModded.Size = new System.Drawing.Size(30, 30);
-            this.pictureModded.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureModded.TabIndex = 20;
-            this.pictureModded.TabStop = false;
-            // 
-            // listDevices
-            // 
-            this.listDevices.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.listDevices.BackColor = System.Drawing.SystemColors.Window;
-            this.listDevices.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.listDevices.FullRowSelect = true;
-            this.listDevices.HideSelection = false;
-            this.listDevices.Location = new System.Drawing.Point(6, 25);
-            this.listDevices.MultiSelect = false;
-            this.listDevices.Name = "listDevices";
-            this.listDevices.Size = new System.Drawing.Size(256, 285);
-            this.listDevices.TabIndex = 1;
-            this.listDevices.TileSize = new System.Drawing.Size(238, 40);
-            this.listDevices.UseCompatibleStateImageBehavior = false;
-            this.listDevices.View = System.Windows.Forms.View.Tile;
-            this.listDevices.SelectedIndexChanged += new System.EventHandler(this.listDevices_SelectedIndexChanged);
-            // 
-            // tabGeneral
-            // 
-            this.tabGeneral.Controls.Add(this.groupBox2);
-            this.tabGeneral.Controls.Add(this.groupBox4);
-            this.tabGeneral.Controls.Add(this.groupBox1);
-            this.tabGeneral.Location = new System.Drawing.Point(4, 22);
-            this.tabGeneral.Name = "tabGeneral";
-            this.tabGeneral.Size = new System.Drawing.Size(532, 316);
-            this.tabGeneral.TabIndex = 2;
-            this.tabGeneral.Text = "General";
-            this.tabGeneral.UseVisualStyleBackColor = true;
-            this.tabGeneral.Enter += new System.EventHandler(this.tabOSD_Enter);
-            this.tabGeneral.Leave += new System.EventHandler(this.tabOSD_Leave);
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.checkQSShowOSD);
-            this.groupBox2.Controls.Add(this.radioQuickSwitch);
-            this.groupBox2.Controls.Add(this.radioAlwaysMenu);
-            this.groupBox2.Controls.Add(this.label5);
-            this.groupBox2.Controls.Add(this.checkShowHWName);
-            this.groupBox2.Controls.Add(this.checkColorVU);
-            this.groupBox2.Controls.Add(this.label6);
-            this.groupBox2.Controls.Add(this.comboDefMode);
-            this.groupBox2.Controls.Add(this.checkDefaultMultiAndComm);
-            this.groupBox2.Location = new System.Drawing.Point(9, 194);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(510, 114);
-            this.groupBox2.TabIndex = 21;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "General Behavior";
-            // 
-            // checkQSShowOSD
-            // 
-            this.checkQSShowOSD.AutoSize = true;
-            this.checkQSShowOSD.Location = new System.Drawing.Point(334, 90);
-            this.checkQSShowOSD.Name = "checkQSShowOSD";
-            this.checkQSShowOSD.Size = new System.Drawing.Size(79, 17);
-            this.checkQSShowOSD.TabIndex = 26;
-            this.checkQSShowOSD.Text = "Show OSD";
-            this.checkQSShowOSD.UseVisualStyleBackColor = true;
-            // 
-            // radioQuickSwitch
-            // 
-            this.radioQuickSwitch.Location = new System.Drawing.Point(315, 54);
-            this.radioQuickSwitch.Name = "radioQuickSwitch";
-            this.radioQuickSwitch.Size = new System.Drawing.Size(187, 33);
-            this.radioQuickSwitch.TabIndex = 24;
-            this.radioQuickSwitch.Text = "menu when AudioSwitch is open, otherwise quick-switches device";
-            this.radioQuickSwitch.UseVisualStyleBackColor = true;
-            this.radioQuickSwitch.CheckedChanged += new System.EventHandler(this.radioQuickSwitch_CheckedChanged);
-            // 
-            // radioAlwaysMenu
-            // 
-            this.radioAlwaysMenu.Checked = true;
-            this.radioAlwaysMenu.Location = new System.Drawing.Point(315, 34);
-            this.radioAlwaysMenu.Name = "radioAlwaysMenu";
-            this.radioAlwaysMenu.Size = new System.Drawing.Size(86, 17);
-            this.radioAlwaysMenu.TabIndex = 23;
-            this.radioAlwaysMenu.TabStop = true;
-            this.radioAlwaysMenu.Text = "always menu";
-            this.radioAlwaysMenu.UseVisualStyleBackColor = true;
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(304, 16);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(149, 13);
-            this.label5.TabIndex = 25;
-            this.label5.Text = "Right-clicking tray icon opens:";
-            // 
-            // checkShowHWName
-            // 
-            this.checkShowHWName.AutoSize = true;
-            this.checkShowHWName.Location = new System.Drawing.Point(14, 69);
-            this.checkShowHWName.Name = "checkShowHWName";
-            this.checkShowHWName.Size = new System.Drawing.Size(186, 17);
-            this.checkShowHWName.TabIndex = 22;
-            this.checkShowHWName.Text = "Show also device hardware name";
-            this.checkShowHWName.UseVisualStyleBackColor = true;
-            // 
-            // checkColorVU
-            // 
-            this.checkColorVU.Location = new System.Drawing.Point(14, 91);
-            this.checkColorVU.Name = "checkColorVU";
-            this.checkColorVU.Size = new System.Drawing.Size(121, 17);
-            this.checkColorVU.TabIndex = 21;
-            this.checkColorVU.Text = "Color LED VU meter";
-            this.checkColorVU.UseVisualStyleBackColor = true;
-            // 
-            // label6
-            // 
-            this.label6.Location = new System.Drawing.Point(11, 24);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(108, 13);
-            this.label6.TabIndex = 18;
-            this.label6.Text = "Default GUI Devices:";
-            // 
-            // comboDefMode
-            // 
-            this.comboDefMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboDefMode.FormattingEnabled = true;
-            this.comboDefMode.Location = new System.Drawing.Point(125, 21);
-            this.comboDefMode.Name = "comboDefMode";
-            this.comboDefMode.Size = new System.Drawing.Size(121, 21);
-            this.comboDefMode.TabIndex = 19;
-            // 
-            // checkDefaultMultiAndComm
-            // 
-            this.checkDefaultMultiAndComm.Location = new System.Drawing.Point(14, 47);
-            this.checkDefaultMultiAndComm.Name = "checkDefaultMultiAndComm";
-            this.checkDefaultMultiAndComm.Size = new System.Drawing.Size(232, 17);
-            this.checkDefaultMultiAndComm.TabIndex = 20;
-            this.checkDefaultMultiAndComm.Text = "Switch also default communications device";
-            this.checkDefaultMultiAndComm.UseVisualStyleBackColor = true;
-            this.checkDefaultMultiAndComm.CheckedChanged += new System.EventHandler(this.checkDefaultMultiAndComm_CheckedChanged);
-            // 
-            // groupBox4
-            // 
-            this.groupBox4.Controls.Add(this.checkVolScroll);
-            this.groupBox4.Controls.Add(this.checkScrShowOSD);
-            this.groupBox4.Controls.Add(this.comboScrollKey);
-            this.groupBox4.Controls.Add(this.labelVolScroll);
-            this.groupBox4.Location = new System.Drawing.Point(9, 135);
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(510, 53);
-            this.groupBox4.TabIndex = 8;
-            this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Volume Scrolling";
-            // 
-            // checkVolScroll
-            // 
-            this.checkVolScroll.Location = new System.Drawing.Point(14, 23);
-            this.checkVolScroll.Name = "checkVolScroll";
-            this.checkVolScroll.Size = new System.Drawing.Size(65, 17);
-            this.checkVolScroll.TabIndex = 22;
-            this.checkVolScroll.Text = "Enabled";
-            this.checkVolScroll.UseVisualStyleBackColor = true;
-            this.checkVolScroll.CheckedChanged += new System.EventHandler(this.checkVolScroll_CheckedChanged);
-            // 
-            // checkScrShowOSD
-            // 
-            this.checkScrShowOSD.Location = new System.Drawing.Point(390, 23);
-            this.checkScrShowOSD.Name = "checkScrShowOSD";
-            this.checkScrShowOSD.Size = new System.Drawing.Size(79, 17);
-            this.checkScrShowOSD.TabIndex = 8;
-            this.checkScrShowOSD.Text = "Show OSD";
-            this.checkScrShowOSD.UseVisualStyleBackColor = true;
-            this.checkScrShowOSD.CheckedChanged += new System.EventHandler(this.checkScrShowOSD_CheckedChanged);
-            // 
-            // comboScrollKey
-            // 
-            this.comboScrollKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboScrollKey.FormattingEnabled = true;
-            this.comboScrollKey.Items.AddRange(new object[] {
-            "LeftMouseButton",
-            "RightMouseButton",
-            "Control",
-            "Alt",
-            "LWin",
-            "RWin",
-            "Shift"});
-            this.comboScrollKey.Location = new System.Drawing.Point(85, 21);
-            this.comboScrollKey.Name = "comboScrollKey";
-            this.comboScrollKey.Size = new System.Drawing.Size(161, 21);
-            this.comboScrollKey.TabIndex = 21;
-            this.comboScrollKey.SelectedIndexChanged += new System.EventHandler(this.comboScrollKey_SelectedIndexChanged);
-            // 
-            // labelVolScroll
-            // 
-            this.labelVolScroll.Location = new System.Drawing.Point(245, 24);
-            this.labelVolScroll.Name = "labelVolScroll";
-            this.labelVolScroll.Size = new System.Drawing.Size(85, 13);
-            this.labelVolScroll.TabIndex = 23;
-            this.labelVolScroll.Text = " + Mouse Wheel";
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.groupBox3);
-            this.groupBox1.Controls.Add(this.numTimeout);
-            this.groupBox1.Controls.Add(this.trackTransparency);
-            this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Controls.Add(this.label8);
-            this.groupBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            this.groupBox1.Location = new System.Drawing.Point(9, 9);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(510, 120);
-            this.groupBox1.TabIndex = 18;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "OSD Settings";
-            // 
-            // groupBox3
-            // 
-            this.groupBox3.Controls.Add(this.labelAuthor);
-            this.groupBox3.Controls.Add(this.linkWebpage);
-            this.groupBox3.Controls.Add(this.labelVersion);
-            this.groupBox3.Controls.Add(this.comboOSDSkin);
-            this.groupBox3.Controls.Add(this.label1);
-            this.groupBox3.Location = new System.Drawing.Point(8, 16);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(273, 99);
-            this.groupBox3.TabIndex = 8;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Skin";
-            // 
-            // labelAuthor
-            // 
-            this.labelAuthor.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            this.labelAuthor.Location = new System.Drawing.Point(15, 47);
-            this.labelAuthor.Name = "labelAuthor";
-            this.labelAuthor.Size = new System.Drawing.Size(208, 13);
-            this.labelAuthor.TabIndex = 8;
-            this.labelAuthor.Text = "<Author>";
-            this.labelAuthor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // linkWebpage
-            // 
-            this.linkWebpage.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
-            this.linkWebpage.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.linkWebpage.Location = new System.Drawing.Point(15, 75);
-            this.linkWebpage.Name = "linkWebpage";
-            this.linkWebpage.Size = new System.Drawing.Size(208, 13);
-            this.linkWebpage.TabIndex = 15;
-            this.linkWebpage.TabStop = true;
-            this.linkWebpage.Text = "<Webpage>";
-            this.linkWebpage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.linkWebpage.VisitedLinkColor = System.Drawing.SystemColors.HotTrack;
-            this.linkWebpage.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkWebpage_LinkClicked);
-            // 
-            // labelVersion
-            // 
-            this.labelVersion.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            this.labelVersion.Location = new System.Drawing.Point(54, 60);
-            this.labelVersion.Name = "labelVersion";
-            this.labelVersion.Size = new System.Drawing.Size(29, 12);
-            this.labelVersion.TabIndex = 16;
-            this.labelVersion.Text = "<ver>";
-            // 
-            // comboOSDSkin
-            // 
-            this.comboOSDSkin.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboOSDSkin.FormattingEnabled = true;
-            this.comboOSDSkin.Location = new System.Drawing.Point(18, 22);
-            this.comboOSDSkin.Name = "comboOSDSkin";
-            this.comboOSDSkin.Size = new System.Drawing.Size(205, 21);
-            this.comboOSDSkin.TabIndex = 12;
-            this.comboOSDSkin.SelectedIndexChanged += new System.EventHandler(this.comboOSDSkin_SelectedIndexChanged);
-            // 
-            // label1
-            // 
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            this.label1.Location = new System.Drawing.Point(16, 60);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(37, 12);
-            this.label1.TabIndex = 8;
-            this.label1.Text = "Version";
-            // 
-            // numTimeout
-            // 
-            this.numTimeout.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.numTimeout.Location = new System.Drawing.Point(421, 79);
-            this.numTimeout.Maximum = new decimal(new int[] {
-            100000,
-            0,
-            0,
-            0});
-            this.numTimeout.Minimum = new decimal(new int[] {
-            500,
-            0,
-            0,
-            -2147483648});
-            this.numTimeout.Name = "numTimeout";
-            this.numTimeout.Size = new System.Drawing.Size(56, 20);
-            this.numTimeout.TabIndex = 10;
-            this.numTimeout.Value = new decimal(new int[] {
-            2000,
-            0,
-            0,
-            0});
-            this.numTimeout.ValueChanged += new System.EventHandler(this.numTimeout_ValueChanged);
-            // 
-            // trackTransparency
-            // 
-            this.trackTransparency.BackColor = System.Drawing.SystemColors.Window;
-            this.trackTransparency.Location = new System.Drawing.Point(317, 37);
-            this.trackTransparency.Maximum = 255;
-            this.trackTransparency.Name = "trackTransparency";
-            this.trackTransparency.Size = new System.Drawing.Size(160, 45);
-            this.trackTransparency.TabIndex = 14;
-            this.trackTransparency.Value = 255;
-            this.trackTransparency.Scroll += new System.EventHandler(this.trackTransparency_ValueChanged);
-            // 
-            // label3
-            // 
-            this.label3.Location = new System.Drawing.Point(308, 81);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(107, 13);
-            this.label3.TabIndex = 11;
-            this.label3.Text = "Closing Timeout (ms):";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // label8
-            // 
-            this.label8.Location = new System.Drawing.Point(314, 17);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(72, 13);
-            this.label8.TabIndex = 8;
-            this.label8.Text = "Transparency";
-            // 
-            // buttonClose
-            // 
-            this.buttonClose.Location = new System.Drawing.Point(410, 347);
-            this.buttonClose.Name = "buttonClose";
-            this.buttonClose.Size = new System.Drawing.Size(132, 30);
-            this.buttonClose.TabIndex = 4;
-            this.buttonClose.Text = "Close";
-            this.buttonClose.UseVisualStyleBackColor = true;
-            this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
-            // 
-            // label4
-            // 
-            this.label4.BackColor = System.Drawing.Color.Transparent;
-            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            this.label4.Location = new System.Drawing.Point(37, 351);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(130, 20);
-            this.label4.TabIndex = 5;
-            this.label4.Text = "AudioSwitch v2.1";
-            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.BackColor = System.Drawing.Color.Transparent;
-            this.pictureBox1.Image = global::AudioSwitch.Properties.Resources.spkr;
-            this.pictureBox1.Location = new System.Drawing.Point(3, 346);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(37, 34);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.pictureBox1.TabIndex = 6;
-            this.pictureBox1.TabStop = false;
-            // 
-            // labelTips
-            // 
-            this.labelTips.ForeColor = System.Drawing.Color.Green;
-            this.labelTips.Location = new System.Drawing.Point(170, 4);
-            this.labelTips.Name = "labelTips";
-            this.labelTips.Size = new System.Drawing.Size(367, 16);
-            this.labelTips.TabIndex = 7;
-            this.labelTips.Text = "labelTips";
-            this.labelTips.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // FormSettings
-            // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.ClientSize = new System.Drawing.Size(547, 380);
-            this.Controls.Add(this.labelTips);
-            this.Controls.Add(this.label4);
-            this.Controls.Add(this.pictureBox1);
-            this.Controls.Add(this.buttonClose);
-            this.Controls.Add(this.tabSettings);
-            this.DoubleBuffered = true;
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "FormSettings";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "AudioSwitch - Settings";
-            this.TopMost = true;
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSettings_FormClosing);
-            this.Load += new System.EventHandler(this.FormSettings_Load);
-            this.tabSettings.ResumeLayout(false);
-            this.tabHotkeys.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.gridHotkeys)).EndInit();
-            this.tabDevices.ResumeLayout(false);
-            this.groupDevice.ResumeLayout(false);
-            this.groupDevice.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackHue)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureModded)).EndInit();
-            this.tabGeneral.ResumeLayout(false);
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.groupBox3.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.numTimeout)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackTransparency)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.ResumeLayout(false);
+			this.gridHotkeys.GridColor = System.Drawing.SystemColors.Control;
+			this.gridHotkeys.Location = new System.Drawing.Point(6, 6);
+			this.gridHotkeys.Name = "gridHotkeys";
+			this.gridHotkeys.RowHeadersWidth = 25;
+			this.gridHotkeys.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
+			dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
+			dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+			dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+			dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+			dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+			this.gridHotkeys.RowsDefaultCellStyle = dataGridViewCellStyle1;
+			this.gridHotkeys.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+			this.gridHotkeys.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+			this.gridHotkeys.Size = new System.Drawing.Size(520, 304);
+			this.gridHotkeys.TabIndex = 1;
+			// 
+			// Function
+			// 
+			this.Function.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+			this.Function.HeaderText = "Function";
+			this.Function.MaxDropDownItems = 100;
+			this.Function.MinimumWidth = 160;
+			this.Function.Name = "Function";
+			this.Function.Width = 160;
+			// 
+			// Control
+			// 
+			this.Control.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+			this.Control.HeaderText = "Control";
+			this.Control.Name = "Control";
+			this.Control.Width = 46;
+			// 
+			// Alt
+			// 
+			this.Alt.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+			this.Alt.HeaderText = "Alt";
+			this.Alt.Name = "Alt";
+			this.Alt.Width = 25;
+			// 
+			// Shift
+			// 
+			this.Shift.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+			this.Shift.HeaderText = "Shift";
+			this.Shift.Name = "Shift";
+			this.Shift.Width = 34;
+			// 
+			// LWin
+			// 
+			this.LWin.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+			this.LWin.HeaderText = "LWin";
+			this.LWin.Name = "LWin";
+			this.LWin.Width = 38;
+			// 
+			// RWin
+			// 
+			this.RWin.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+			this.RWin.HeaderText = "RWin";
+			this.RWin.Name = "RWin";
+			this.RWin.Width = 40;
+			// 
+			// ShowOSD
+			// 
+			this.ShowOSD.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+			this.ShowOSD.HeaderText = "Show OSD";
+			this.ShowOSD.Name = "ShowOSD";
+			this.ShowOSD.Width = 66;
+			// 
+			// HotKey
+			// 
+			this.HotKey.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+			this.HotKey.HeaderText = "Hot Key";
+			this.HotKey.MaxDropDownItems = 20;
+			this.HotKey.MinimumWidth = 80;
+			this.HotKey.Name = "HotKey";
+			// 
+			// buttonClose
+			// 
+			this.buttonClose.Location = new System.Drawing.Point(410, 347);
+			this.buttonClose.Name = "buttonClose";
+			this.buttonClose.Size = new System.Drawing.Size(132, 30);
+			this.buttonClose.TabIndex = 4;
+			this.buttonClose.Text = "Close";
+			this.buttonClose.UseVisualStyleBackColor = true;
+			this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
+			// 
+			// label4
+			// 
+			this.label4.BackColor = System.Drawing.Color.Transparent;
+			this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+			this.label4.Location = new System.Drawing.Point(37, 351);
+			this.label4.Name = "label4";
+			this.label4.Size = new System.Drawing.Size(130, 20);
+			this.label4.TabIndex = 5;
+			this.label4.Text = "AudioSwitch v2.1";
+			this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// pictureBox1
+			// 
+			this.pictureBox1.BackColor = System.Drawing.Color.Transparent;
+			this.pictureBox1.Image = global::AudioSwitch.Properties.Resources.spkr;
+			this.pictureBox1.Location = new System.Drawing.Point(3, 346);
+			this.pictureBox1.Name = "pictureBox1";
+			this.pictureBox1.Size = new System.Drawing.Size(37, 34);
+			this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+			this.pictureBox1.TabIndex = 6;
+			this.pictureBox1.TabStop = false;
+			// 
+			// labelTips
+			// 
+			this.labelTips.ForeColor = System.Drawing.Color.Green;
+			this.labelTips.Location = new System.Drawing.Point(170, 4);
+			this.labelTips.Name = "labelTips";
+			this.labelTips.Size = new System.Drawing.Size(367, 16);
+			this.labelTips.TabIndex = 7;
+			this.labelTips.Text = "labelTips";
+			this.labelTips.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// FormSettings
+			// 
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+			this.ClientSize = new System.Drawing.Size(547, 380);
+			this.Controls.Add(this.labelTips);
+			this.Controls.Add(this.label4);
+			this.Controls.Add(this.pictureBox1);
+			this.Controls.Add(this.buttonClose);
+			this.Controls.Add(this.tabSettings);
+			this.DoubleBuffered = true;
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "FormSettings";
+			this.ShowIcon = false;
+			this.ShowInTaskbar = false;
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+			this.Text = "AudioSwitch - Settings";
+			this.TopMost = true;
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSettings_FormClosing);
+			this.Load += new System.EventHandler(this.FormSettings_Load);
+			this.tabSettings.ResumeLayout(false);
+			this.tabGeneral.ResumeLayout(false);
+			this.groupBox2.ResumeLayout(false);
+			this.groupBox2.PerformLayout();
+			this.groupBox4.ResumeLayout(false);
+			this.groupBox1.ResumeLayout(false);
+			this.groupBox1.PerformLayout();
+			this.groupBox3.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.numTimeout)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.trackTransparency)).EndInit();
+			this.tabDevices.ResumeLayout(false);
+			this.groupDevice.ResumeLayout(false);
+			this.groupDevice.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.trackHue)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.pictureModded)).EndInit();
+			this.tabHotkeys.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.gridHotkeys)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+			this.ResumeLayout(false);
 
         }
 
@@ -846,5 +867,7 @@ namespace AudioSwitch.Forms
         private System.Windows.Forms.RadioButton radioQuickSwitch;
         private System.Windows.Forms.RadioButton radioAlwaysMenu;
         private System.Windows.Forms.CheckBox checkQSShowOSD;
-    }
+		private System.Windows.Forms.Label label12;
+		private System.Windows.Forms.TextBox txtDisplayName;
+	}
 }

--- a/Forms/FormSettings.cs
+++ b/Forms/FormSettings.cs
@@ -59,6 +59,9 @@ namespace AudioSwitch.Forms
 
                     if (devSettings.HideFromList)
                         lvitem.Font = new Font(lvitem.Font, FontStyle.Italic);
+
+					if (devSettings.DisplayName != "")
+						lvitem.Text += " [" + devSettings.DisplayName + "]";
                 }
 
                 listDevices.LargeImageList.Images.Add(dev.Value);
@@ -207,8 +210,7 @@ namespace AudioSwitch.Forms
             trackBrightness.Value = 0;
             pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
             checkHideDevice.Checked = false;
-			// TODO: change this to load default device name
-			txtDisplayName.Text = "Default Name";
+			txtDisplayName.Text = "";
 
             listDevices.SelectedItems[0].Font = new Font(listDevices.SelectedItems[0].Font, FontStyle.Regular);
 
@@ -261,8 +263,7 @@ namespace AudioSwitch.Forms
                 trackSaturation.Value = 0;
                 pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
                 checkHideDevice.Checked = false;
-				// TODO: change this to load default device name
-				txtDisplayName.Text = "Default Name";
+				txtDisplayName.Text = "";
 
 				return;
             }

--- a/Forms/FormSettings.cs
+++ b/Forms/FormSettings.cs
@@ -207,6 +207,8 @@ namespace AudioSwitch.Forms
             trackBrightness.Value = 0;
             pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
             checkHideDevice.Checked = false;
+			// TODO: change this to load default device name
+			txtDisplayName.Text = "Default Name";
 
             listDevices.SelectedItems[0].Font = new Font(listDevices.SelectedItems[0].Font, FontStyle.Regular);
 
@@ -230,17 +232,19 @@ namespace AudioSwitch.Forms
                 devSettings.Hue = trackHue.Value;
                 devSettings.Saturation = trackSaturation.Value;
                 devSettings.HideFromList = checkHideDevice.Checked;
+				devSettings.DisplayName = txtDisplayName.Text;
             }
             else
             {
-                devSettings = new Settings.CDevice
-                    {
-                        DeviceID = (string) listDevices.SelectedItems[0].Tag,
-                        HideFromList = checkHideDevice.Checked,
-                        Brightness = trackBrightness.Value,
-                        Hue = trackHue.Value,
-                        Saturation = trackSaturation.Value
-                    };
+				devSettings = new Settings.CDevice
+				{
+					DeviceID = (string)listDevices.SelectedItems[0].Tag,
+					HideFromList = checkHideDevice.Checked,
+					Brightness = trackBrightness.Value,
+					Hue = trackHue.Value,
+					Saturation = trackSaturation.Value,
+					DisplayName = txtDisplayName.Text
+                };
                 Program.settings.Device.Add(devSettings);
             }
         }
@@ -257,12 +261,16 @@ namespace AudioSwitch.Forms
                 trackSaturation.Value = 0;
                 pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
                 checkHideDevice.Checked = false;
-                return;
+				// TODO: change this to load default device name
+				txtDisplayName.Text = "Default Name";
+
+				return;
             }
 
             trackBrightness.Value = devSettings.Brightness;
             trackHue.Value = devSettings.Hue;
             trackSaturation.Value = devSettings.Saturation;
+			txtDisplayName.Text = devSettings.DisplayName;
 
             pictureModded.Image?.Dispose();
             pictureModded.Image = DeviceIcons.ChangeColors(new Bitmap(Properties.Resources._66_100_highDPI), trackHue.Value, trackSaturation.Value / 100f, trackBrightness.Value / 100f);
@@ -320,5 +328,5 @@ namespace AudioSwitch.Forms
         {
             checkQSShowOSD.Enabled = radioQuickSwitch.Checked;
         }
-    }
+	}
 }

--- a/Forms/FormSwitcher.Designer.cs
+++ b/Forms/FormSwitcher.Designer.cs
@@ -37,167 +37,172 @@ namespace AudioSwitch.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
-            this.trayMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.audioDevicesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.timer1 = new System.Windows.Forms.Timer(this.components);
-            this.ledRight = new AudioSwitch.Controls.LedBar();
-            this.ledLeft = new AudioSwitch.Controls.LedBar();
-            this.VolBar = new AudioSwitch.Controls.VolumeBar();
-            this.listDevices = new AudioSwitch.Controls.CustomListView();
-            this.pictureShadow = new System.Windows.Forms.PictureBox();
-            this.pictureItemsBack = new System.Windows.Forms.PictureBox();
-            this.trayMenu.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureShadow)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureItemsBack)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // notifyIcon
-            // 
-            this.notifyIcon.Text = "AudioSwitch";
-            this.notifyIcon.Visible = true;
-            this.notifyIcon.MouseDown += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseDown);
-            this.notifyIcon.MouseMove += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseMove);
-            this.notifyIcon.MouseUp += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseUp);
-            // 
-            // trayMenu
-            // 
-            this.trayMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.components = new System.ComponentModel.Container();
+			this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
+			this.trayMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.audioDevicesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.timer1 = new System.Windows.Forms.Timer(this.components);
+			this.pictureShadow = new System.Windows.Forms.PictureBox();
+			this.pictureItemsBack = new System.Windows.Forms.PictureBox();
+			this.ledRight = new AudioSwitch.Controls.LedBar();
+			this.ledLeft = new AudioSwitch.Controls.LedBar();
+			this.VolBar = new AudioSwitch.Controls.VolumeBar();
+			this.listDevices = new AudioSwitch.Controls.CustomListView();
+			this.trayMenu.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.pictureShadow)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.pictureItemsBack)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// notifyIcon
+			// 
+			this.notifyIcon.Text = "AudioSwitch";
+			this.notifyIcon.Visible = true;
+			this.notifyIcon.MouseDown += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseDown);
+			this.notifyIcon.MouseMove += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseMove);
+			this.notifyIcon.MouseUp += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseUp);
+			// 
+			// trayMenu
+			// 
+			this.trayMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.settingsToolStripMenuItem,
             this.audioDevicesToolStripMenuItem,
             this.toolStripSeparator1,
             this.exitToolStripMenuItem});
-            this.trayMenu.Name = "trayMenu";
-            this.trayMenu.Size = new System.Drawing.Size(150, 76);
-            // 
-            // settingsToolStripMenuItem
-            // 
-            this.settingsToolStripMenuItem.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
-            this.settingsToolStripMenuItem.Text = "&Settings";
-            this.settingsToolStripMenuItem.Click += new System.EventHandler(this.settingsToolStripMenuItem_Click);
-            // 
-            // audioDevicesToolStripMenuItem
-            // 
-            this.audioDevicesToolStripMenuItem.Name = "audioDevicesToolStripMenuItem";
-            this.audioDevicesToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
-            this.audioDevicesToolStripMenuItem.Text = "Audio Devices";
-            this.audioDevicesToolStripMenuItem.Click += new System.EventHandler(this.audioDevicesToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(146, 6);
-            // 
-            // exitToolStripMenuItem
-            // 
-            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
-            this.exitToolStripMenuItem.Text = "E&xit";
-            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
-            // 
-            // timer1
-            // 
-            this.timer1.Interval = 1;
-            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
-            // 
-            // ledRight
-            // 
-            this.ledRight.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.ledRight.BackColor = System.Drawing.SystemColors.Control;
-            this.ledRight.Location = new System.Drawing.Point(12, 219);
-            this.ledRight.Name = "ledRight";
-            this.ledRight.OldStyle = false;
-            this.ledRight.Size = new System.Drawing.Size(196, 6);
-            this.ledRight.TabIndex = 9;
-            this.ledRight.TabStop = false;
-            // 
-            // ledLeft
-            // 
-            this.ledLeft.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.ledLeft.BackColor = System.Drawing.SystemColors.Control;
-            this.ledLeft.Location = new System.Drawing.Point(12, 202);
-            this.ledLeft.Name = "ledLeft";
-            this.ledLeft.OldStyle = false;
-            this.ledLeft.Size = new System.Drawing.Size(196, 6);
-            this.ledLeft.TabIndex = 8;
-            this.ledLeft.TabStop = false;
-            // 
-            // VolBar
-            // 
-            this.VolBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.VolBar.Location = new System.Drawing.Point(13, 209);
-            this.VolBar.Name = "VolBar";
-            this.VolBar.Size = new System.Drawing.Size(195, 9);
-            this.VolBar.TabIndex = 7;
-            this.VolBar.TabStop = false;
-            // 
-            // listDevices
-            // 
-            this.listDevices.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.trayMenu.Name = "trayMenu";
+			this.trayMenu.Size = new System.Drawing.Size(150, 76);
+			// 
+			// settingsToolStripMenuItem
+			// 
+			this.settingsToolStripMenuItem.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+			this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
+			this.settingsToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
+			this.settingsToolStripMenuItem.Text = "&Settings";
+			this.settingsToolStripMenuItem.Click += new System.EventHandler(this.settingsToolStripMenuItem_Click);
+			// 
+			// audioDevicesToolStripMenuItem
+			// 
+			this.audioDevicesToolStripMenuItem.Name = "audioDevicesToolStripMenuItem";
+			this.audioDevicesToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
+			this.audioDevicesToolStripMenuItem.Text = "Audio Devices";
+			this.audioDevicesToolStripMenuItem.Click += new System.EventHandler(this.audioDevicesToolStripMenuItem_Click);
+			// 
+			// toolStripSeparator1
+			// 
+			this.toolStripSeparator1.Name = "toolStripSeparator1";
+			this.toolStripSeparator1.Size = new System.Drawing.Size(146, 6);
+			// 
+			// exitToolStripMenuItem
+			// 
+			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+			this.exitToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
+			this.exitToolStripMenuItem.Text = "E&xit";
+			this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+			// 
+			// timer1
+			// 
+			this.timer1.Interval = 1;
+			this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+			// 
+			// pictureShadow
+			// 
+			this.pictureShadow.BackgroundImage = global::AudioSwitch.Properties.Resources.shadow;
+			this.pictureShadow.Location = new System.Drawing.Point(0, 192);
+			this.pictureShadow.Name = "pictureShadow";
+			this.pictureShadow.Size = new System.Drawing.Size(221, 6);
+			this.pictureShadow.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+			this.pictureShadow.TabIndex = 10;
+			this.pictureShadow.TabStop = false;
+			// 
+			// pictureItemsBack
+			// 
+			this.pictureItemsBack.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this.pictureItemsBack.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(22)))), ((int)(((byte)(22)))));
+			this.pictureItemsBack.Location = new System.Drawing.Point(0, 192);
+			this.pictureItemsBack.Name = "pictureItemsBack";
+			this.pictureItemsBack.Size = new System.Drawing.Size(221, 43);
+			this.pictureItemsBack.TabIndex = 2;
+			this.pictureItemsBack.TabStop = false;
+			// 
+			// ledRight
+			// 
+			this.ledRight.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this.ledRight.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(22)))), ((int)(((byte)(22)))));
+			this.ledRight.Location = new System.Drawing.Point(12, 219);
+			this.ledRight.Name = "ledRight";
+			this.ledRight.OldStyle = false;
+			this.ledRight.Size = new System.Drawing.Size(196, 6);
+			this.ledRight.TabIndex = 9;
+			this.ledRight.TabStop = false;
+			// 
+			// ledLeft
+			// 
+			this.ledLeft.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this.ledLeft.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(22)))), ((int)(((byte)(22)))));
+			this.ledLeft.Location = new System.Drawing.Point(12, 202);
+			this.ledLeft.Name = "ledLeft";
+			this.ledLeft.OldStyle = false;
+			this.ledLeft.Size = new System.Drawing.Size(196, 6);
+			this.ledLeft.TabIndex = 8;
+			this.ledLeft.TabStop = false;
+			// 
+			// VolBar
+			// 
+			this.VolBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this.VolBar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(22)))), ((int)(((byte)(22)))));
+			this.VolBar.Location = new System.Drawing.Point(13, 209);
+			this.VolBar.Name = "VolBar";
+			this.VolBar.Size = new System.Drawing.Size(195, 9);
+			this.VolBar.TabIndex = 7;
+			this.VolBar.TabStop = false;
+			// 
+			// listDevices
+			// 
+			this.listDevices.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.listDevices.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.listDevices.FullRowSelect = true;
-            this.listDevices.HideSelection = false;
-            this.listDevices.Location = new System.Drawing.Point(1, -1);
-            this.listDevices.MultiSelect = false;
-            this.listDevices.Name = "listDevices";
-            this.listDevices.Size = new System.Drawing.Size(220, 437);
-            this.listDevices.TabIndex = 0;
-            this.listDevices.TileSize = new System.Drawing.Size(222, 40);
-            this.listDevices.UseCompatibleStateImageBehavior = false;
-            this.listDevices.View = System.Windows.Forms.View.Tile;
-            this.listDevices.Click += new System.EventHandler(this.listDevices_Click);
-            // 
-            // pictureShadow
-            // 
-            this.pictureShadow.BackgroundImage = global::AudioSwitch.Properties.Resources.shadow;
-            this.pictureShadow.Location = new System.Drawing.Point(0, 192);
-            this.pictureShadow.Name = "pictureShadow";
-            this.pictureShadow.Size = new System.Drawing.Size(221, 6);
-            this.pictureShadow.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureShadow.TabIndex = 10;
-            this.pictureShadow.TabStop = false;
-            // 
-            // pictureItemsBack
-            // 
-            this.pictureItemsBack.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.pictureItemsBack.Location = new System.Drawing.Point(0, 192);
-            this.pictureItemsBack.Name = "pictureItemsBack";
-            this.pictureItemsBack.Size = new System.Drawing.Size(221, 43);
-            this.pictureItemsBack.TabIndex = 2;
-            this.pictureItemsBack.TabStop = false;
-            // 
-            // FormSwitcher
-            // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.ClientSize = new System.Drawing.Size(220, 234);
-            this.ControlBox = false;
-            this.Controls.Add(this.pictureShadow);
-            this.Controls.Add(this.ledRight);
-            this.Controls.Add(this.ledLeft);
-            this.Controls.Add(this.VolBar);
-            this.Controls.Add(this.pictureItemsBack);
-            this.Controls.Add(this.listDevices);
-            this.DoubleBuffered = true;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "FormSwitcher";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
-            this.TopMost = true;
-            this.Deactivate += new System.EventHandler(this.FormSwitcher_Deactivate);
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSwitcher_FormClosing);
-            this.trayMenu.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureShadow)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureItemsBack)).EndInit();
-            this.ResumeLayout(false);
+			this.listDevices.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(22)))), ((int)(((byte)(22)))));
+			this.listDevices.BorderStyle = System.Windows.Forms.BorderStyle.None;
+			this.listDevices.FullRowSelect = true;
+			this.listDevices.HideSelection = false;
+			this.listDevices.Location = new System.Drawing.Point(1, -1);
+			this.listDevices.MultiSelect = false;
+			this.listDevices.Name = "listDevices";
+			this.listDevices.Size = new System.Drawing.Size(220, 437);
+			this.listDevices.TabIndex = 0;
+			this.listDevices.TileSize = new System.Drawing.Size(222, 40);
+			this.listDevices.UseCompatibleStateImageBehavior = false;
+			this.listDevices.View = System.Windows.Forms.View.Tile;
+			this.listDevices.Click += new System.EventHandler(this.listDevices_Click);
+			// 
+			// FormSwitcher
+			// 
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+			this.BackColor = System.Drawing.SystemColors.WindowText;
+			this.ClientSize = new System.Drawing.Size(220, 234);
+			this.ControlBox = false;
+			this.Controls.Add(this.pictureShadow);
+			this.Controls.Add(this.ledRight);
+			this.Controls.Add(this.ledLeft);
+			this.Controls.Add(this.VolBar);
+			this.Controls.Add(this.pictureItemsBack);
+			this.Controls.Add(this.listDevices);
+			this.DoubleBuffered = true;
+			this.ForeColor = System.Drawing.SystemColors.ControlText;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "FormSwitcher";
+			this.ShowIcon = false;
+			this.ShowInTaskbar = false;
+			this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
+			this.TopMost = true;
+			this.Deactivate += new System.EventHandler(this.FormSwitcher_Deactivate);
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSwitcher_FormClosing);
+			this.trayMenu.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.pictureShadow)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.pictureItemsBack)).EndInit();
+			this.ResumeLayout(false);
 
         }
 

--- a/Forms/FormSwitcher.cs
+++ b/Forms/FormSwitcher.cs
@@ -149,12 +149,14 @@ namespace AudioSwitch.Forms
                             var device = pDevices[i];
                             DeviceIcons.Add(device.IconPath);
                             var devSettings = Program.settings.Device.Find(x => x.DeviceID == devID);
-                            if (devSettings == null || !devSettings.HideFromList)
+							var displayName = devSettings != null && devSettings.DisplayName != "" ? devSettings.DisplayName : device.FriendlyName;
+
+							if (devSettings == null || !devSettings.HideFromList)
                             {
                                 var item = new ListViewItem
                                 {
                                     ImageIndex = listDevices.Items.Count,
-                                    Text = device.FriendlyName,
+                                    Text = displayName,
                                     Tag = devID,
                                 };
 
@@ -422,12 +424,15 @@ namespace AudioSwitch.Forms
 
                     DeviceIcons.Add(device.IconPath);
                     var devSettings = Program.settings.Device.Find(x => x.DeviceID == devID);
-                    if (devSettings == null || !devSettings.HideFromList)
+
+					var displayName = devSettings != null && devSettings.DisplayName != "" ? devSettings.DisplayName : device.FriendlyName;
+
+					if (devSettings == null || !devSettings.HideFromList)
                     {
                         var item = new ListViewItem
                         {
                             ImageIndex = i,
-                            Text = device.FriendlyName,
+                            Text = displayName,
                             Selected = devID == defaultDev,
                             Tag = devID,
                         };

--- a/Forms/FormSwitcher.cs
+++ b/Forms/FormSwitcher.cs
@@ -160,7 +160,9 @@ namespace AudioSwitch.Forms
                                     Tag = devID,
                                 };
 
-                                listDevices.Items.Add(item);
+								item.ForeColor = Color.GhostWhite;
+
+								listDevices.Items.Add(item);
                             }
                             listDevices.Sort();
                             SetSizes();
@@ -436,8 +438,10 @@ namespace AudioSwitch.Forms
                             Selected = devID == defaultDev,
                             Tag = devID,
                         };
-                        
-                        listDevices.Items.Add(item);
+
+						item.ForeColor = Color.GhostWhite;
+
+						listDevices.Items.Add(item);
 
                         if (devID == defaultDev)
                         {


### PR DESCRIPTION
I made some changes that allows the user to provide an override display name for a device. If that property is set, the switcher uses that name instead of the friendly device name.

Please let me know if there are any changes you would like me to make.
