### PR TITLE
Fixed custom name check/text not updated when selecting a device...

### DIFF
--- a/Forms/FormSettings.cs
+++ b/Forms/FormSettings.cs
@@ -277,6 +277,9 @@ namespace AudioSwitch.Forms
             pictureModded.Image?.Dispose();
             pictureModded.Image = DeviceIcons.ChangeColors(new Bitmap(Properties.Resources._66_100_highDPI), trackHue.Value, trackSaturation.Value / 100f, trackBrightness.Value / 100f);
             checkHideDevice.Checked = devSettings.HideFromList;
+
+            checkCustomName.Checked = devSettings.UseCustomName;
+            textCustomName.Text = devSettings.CustomName;
         }
 
         private void comboOSDSkin_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
Just found out I forgot to copy these two lines when preparing my previous pull request a while ago. The customized name would save and be used properly in the popup, but it wouldn't load back in the settings form.
