### PR TITLE
Sort devices by name in ListView

### DIFF
--- a/Controls/CustomListView.cs
+++ b/Controls/CustomListView.cs
@@ -10,6 +10,7 @@ namespace AudioSwitch.Controls
         public CustomListView()
         {
             DoubleBuffered = true;
+            Sorting = SortOrder.Ascending;
         }
 
         protected override void WndProc(ref Message m)

--- a/Forms/FormSwitcher.cs
+++ b/Forms/FormSwitcher.cs
@@ -125,7 +125,7 @@ namespace AudioSwitch.Forms
                         SetTrayIcons();
                         VolBar.RegisterDevice(RenderType);
                     }
-                    SetDeviceIcon(item.Index, item.Selected);
+                    SetDeviceIcon(item.ImageIndex, item.Selected);
                 }
             }
         }


### PR DESCRIPTION
I think it's better to sort the devices alphabetically - through naming it's possible to stack the output/input devices for easier switch (e.g., first is my usb headset, 2nd my speaker/webcam combo, 3rd the 3.5mm analog headset/microphone) rather than showing the devices in the order that Windows has them. Random.