### PR TITLE
Add options to set multimedia and communications device on startup

### DIFF
--- a/AudioSwitch.csproj
+++ b/AudioSwitch.csproj
@@ -95,17 +95,27 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="System.Runtime" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
+    <Compile Include="Classes\Device.cs" />
+    <Compile Include="Classes\DeviceRepository.cs" />
     <Compile Include="Classes\EndPoints.cs" />
     <Compile Include="Classes\OSDskin.cs" />
     <Compile Include="Classes\ScrollVolume.cs" />
+    <Compile Include="Classes\StartupDeviceTask,.cs" />
     <Compile Include="Classes\Win32.cs" />
     <Compile Include="Classes\GlobalHotkeys.cs" />
     <Compile Include="Classes\Hotkey.cs" />
     <Compile Include="Classes\Settings.cs" />
+    <Compile Include="Controls\Devices.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\Devices.Designer.cs">
+      <DependentUpon>Devices.cs</DependentUpon>
+    </Compile>
     <Compile Include="CoreAudioApi\AudioEndpointVolume.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -263,6 +273,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Controls\CustomListView.resx">
       <DependentUpon>CustomListView.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Controls\Devices.resx">
+      <DependentUpon>Devices.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\FormOSD.resx">
       <DependentUpon>FormOSD.cs</DependentUpon>

--- a/Classes/Device.cs
+++ b/Classes/Device.cs
@@ -1,0 +1,16 @@
+﻿using AudioSwitch.CoreAudioApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static AudioSwitch.Classes.Settings;
+
+namespace AudioSwitch.Classes
+{
+    internal class Device
+    {
+        internal MMDevice MMDevice { get; set; }
+        internal EDataFlow DataFlow { get; set; }
+    }
+}

--- a/Classes/DeviceRepository.cs
+++ b/Classes/DeviceRepository.cs
@@ -1,0 +1,89 @@
+﻿using AudioSwitch.CoreAudioApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AudioSwitch.Classes
+{
+    class DeviceRepository
+    {
+
+        static DeviceRepository()
+        {
+            DeviceEnumerator = new MMDeviceEnumerator();
+            //NotifyClient = new MMDeviceNotifyClient();
+            //DeviceEnumerator.RegisterEndpointNotificationCallback(NotifyClient);
+        }
+        internal static readonly MMDeviceEnumerator DeviceEnumerator;
+
+        internal static List<Device> FindAll()
+        {
+            List<Device> deviceList = new List<Device>();
+            deviceList.AddRange(createDeviceList(EDataFlow.eCapture));
+            deviceList.AddRange(createDeviceList(EDataFlow.eRender));
+            return deviceList;
+        }
+
+        internal static List<Device> FindCaptureDevices()
+        {
+            List<Device> deviceList = new List<Device>();
+            deviceList.AddRange(createDeviceList(EDataFlow.eCapture));
+            return deviceList;
+        }
+
+        internal static List<Device> FindPlayBackDevices()
+        {
+            List<Device> deviceList = new List<Device>();
+            deviceList.AddRange(createDeviceList(EDataFlow.eRender));
+            return deviceList;
+        }
+        private static List<Device> createDeviceList(EDataFlow dataFlow)
+        {
+            var devices = DeviceEnumerator.EnumerateAudioEndPoints(dataFlow, EDeviceState.Active);
+            var count = devices.Count;
+            List<Device> deviceList = new List<Device>();
+            for (var i = 0; i < count; i++)
+            {
+                var device = createDevice(devices[i], dataFlow);
+                if (device != null)
+                {
+                    deviceList.Add(device);
+                }
+            }
+            return deviceList;
+        }
+
+        private static Device createDevice(MMDevice mmDevice, EDataFlow dataFlow)
+        {
+            var devId = (string)mmDevice.ID;
+            var devSettings = Program.settings.Device.Find(x => x.DeviceID == devId);
+            if (devSettings == null || !devSettings.HideFromList)
+            {
+                if (devSettings == null)
+                {
+                    devSettings = new Settings.CDevice
+                    {
+                        DeviceID = devId,
+                        HideFromList = false,
+                        Brightness = 0,
+                        Hue = 0,
+                        Saturation = 0,
+                        UseCustomName = false,
+                        CustomName = "",
+                        DefaultMultimediaDevice = false,
+                        DefaultCommunicationsDevice = false
+                    };
+                }
+                var device = new Device
+                {
+                    MMDevice = mmDevice,
+                    DataFlow = dataFlow
+                };
+                return device;
+            }
+            return null;
+        }
+    }
+}

--- a/Classes/EndPoints.cs
+++ b/Classes/EndPoints.cs
@@ -85,7 +85,12 @@ namespace AudioSwitch.Classes
         {
             return DeviceEnumerator.GetDefaultAudioEndpoint(renderType, ERole.eMultimedia);
         }
-        
+
+        internal static MMDevice GetDefaultMMDevice(EDataFlow renderType, ERole erole)
+        {
+            return DeviceEnumerator.GetDefaultAudioEndpoint(renderType, erole);
+        }
+
         internal static Dictionary<MMDevice, Icon> GetAllDeviceList()
         {
             var devices = new Dictionary<MMDevice, Icon>();
@@ -124,6 +129,11 @@ namespace AudioSwitch.Classes
             pPolicyConfig.SetDefaultEndpoint(devID, ERole.eMultimedia);
             if (Program.settings.DefaultMultimediaAndComm)
                 pPolicyConfig.SetDefaultEndpoint(devID, ERole.eCommunications);
+        }
+
+        internal static void SetDefaultDevice(string devID, ERole erole)
+        {
+            pPolicyConfig.SetDefaultEndpoint(devID, erole);
         }
     }
 }

--- a/Classes/Program.cs
+++ b/Classes/Program.cs
@@ -210,9 +210,15 @@ namespace AudioSwitch.Classes
 
                     Application.EnableVisualStyles();
                     Application.SetCompatibleTextRenderingDefault(false);
+
                     frmOSD = new FormOSD();
                     var formSwitcher = new FormSwitcher();
+
+
+                    StartupDeviceTask startupDeviceTask = new StartupDeviceTask();
+                    startupDeviceTask.Run();
                     Application.Run();
+
                     mutex.Close();
                 }
             }

--- a/Classes/Settings.cs
+++ b/Classes/Settings.cs
@@ -96,6 +96,8 @@ namespace AudioSwitch.Classes
             [XmlAttribute] public int Brightness;
             [XmlAttribute] public bool UseCustomName;
             [XmlAttribute] public string CustomName;
+            [XmlAttribute] public bool DefaultMultimediaDevice;
+            [XmlAttribute] public bool DefaultCommunicationsDevice;
         }
 
         internal void Save()

--- a/Classes/StartupDeviceTask,.cs
+++ b/Classes/StartupDeviceTask,.cs
@@ -1,0 +1,102 @@
+﻿using AudioSwitch.CoreAudioApi;
+using AudioSwitch.Forms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows;
+using static AudioSwitch.Classes.Settings;
+
+namespace AudioSwitch.Classes
+{
+    class StartupDeviceTask
+    {
+        public void Run()
+        {
+            var devices = DeviceRepository.FindAll();
+            List<DeviceChanges> devicesSet = new List<DeviceChanges>();
+            foreach (var dev in devices)
+            {
+                var devID = dev.MMDevice.ID;
+                var devSettings = Program.settings.Device.Find(x => x.DeviceID == devID);
+                if (devSettings != null) { 
+                    if (devSettings.DefaultMultimediaDevice)
+                    {
+                        var changes = switchDevice(devSettings, dev, ERole.eMultimedia);
+                        if(changes != null)
+                        {
+                            devicesSet.Add(changes);
+                        }
+                    }
+                    if (devSettings.DefaultCommunicationsDevice)
+                    {
+                        var changes = switchDevice(devSettings, dev, ERole.eCommunications);
+                        if (changes != null)
+                        {
+                            devicesSet.Add(changes);
+                        }
+                    }
+                }
+            }
+            if (devicesSet.Count > 0) {
+                ShowBalloonTip(devicesSet);
+            }
+
+        }
+
+        private DeviceChanges switchDevice(CDevice devSettings, Device dev, CoreAudioApi.ERole role)
+        {
+            var defaultDevice = EndPoints.GetDefaultMMDevice(dev.DataFlow, role);
+            if (defaultDevice == null || defaultDevice.ID == null || !defaultDevice.ID.Equals(devSettings.DeviceID))
+            {
+                EndPoints.SetDefaultDevice(devSettings.DeviceID, role);
+                string deviceName = devSettings.UseCustomName && devSettings.CustomName != null && devSettings.CustomName != "" ? devSettings.CustomName : dev.MMDevice.FriendlyName;
+                return new DeviceChanges { deviceName = deviceName, role = role, dataflow = dev.DataFlow };
+            }
+            return null;
+        }
+
+        private void ShowBalloonTip(List<DeviceChanges> deviceNames)
+        {
+            var attributes = typeof(Program).GetTypeInfo().Assembly.GetCustomAttributes(typeof(AssemblyTitleAttribute));
+            var assemblyTitleAttribute = attributes.SingleOrDefault() as AssemblyTitleAttribute;
+            var text = String.Join("\n", deviceNames.Select(n => "Switching to " + 
+            (EDataFlow.eRender.Equals(n.dataflow) ? "Multimedia" : "Recording")
+            + " \"" + n.deviceName + "\" as default " + 
+            (ERole.eMultimedia.Equals(n.role) ? "multimedia" : "communications") + " device."));
+            var notification = new System.Windows.Forms.NotifyIcon()
+            {
+                Visible = true,
+                Icon = System.Drawing.SystemIcons.Information,
+                BalloonTipTitle = assemblyTitleAttribute.Title,
+                BalloonTipText = text,
+
+            };
+            notification.BalloonTipClicked += new EventHandler(TrayNotifyIcon_BalloonClick);
+            notification.ShowBalloonTip(2);
+            DisposeBalloon(notification).ContinueWith(t => Console.WriteLine(t.Exception),
+                TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        private void TrayNotifyIcon_BalloonClick(object sender, EventArgs e)
+        {
+            var cfg = new FormSettings();
+            cfg.ShowDialog();
+        }
+
+
+        private async Task DisposeBalloon(System.Windows.Forms.NotifyIcon notification)
+        {
+            System.Threading.Thread.Sleep(2000);
+            notification.Dispose();
+        }
+
+        internal class DeviceChanges
+        {
+            internal string deviceName { get; set; }
+            internal ERole role { get; set; }
+            internal EDataFlow dataflow { get; set; }
+        }
+    }
+}

--- a/Controls/Devices.Designer.cs
+++ b/Controls/Devices.Designer.cs
@@ -1,0 +1,306 @@
+﻿namespace AudioSwitch.Forms
+{
+    partial class Devices
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.listDevices = new AudioSwitch.Controls.CustomListView();
+            this.label4 = new System.Windows.Forms.Label();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.checkEnableAsCommunicationsOnStartup = new System.Windows.Forms.CheckBox();
+            this.checkEnableAsMultimediaOnStartup = new System.Windows.Forms.CheckBox();
+            this.checkCustomName = new System.Windows.Forms.CheckBox();
+            this.pictureModded = new System.Windows.Forms.PictureBox();
+            this.textCustomName = new System.Windows.Forms.TextBox();
+            this.label12 = new System.Windows.Forms.Label();
+            this.checkHideDevice = new System.Windows.Forms.CheckBox();
+            this.label13 = new System.Windows.Forms.Label();
+            this.label14 = new System.Windows.Forms.Label();
+            this.label15 = new System.Windows.Forms.Label();
+            this.buttonRemove = new System.Windows.Forms.Button();
+            this.buttonSave = new System.Windows.Forms.Button();
+            this.trackBrightness = new System.Windows.Forms.TrackBar();
+            this.trackSaturation = new System.Windows.Forms.TrackBar();
+            this.trackHue = new System.Windows.Forms.TrackBar();
+            this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureModded)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackHue)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // listDevices
+            // 
+            this.listDevices.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.listDevices.BackColor = System.Drawing.SystemColors.Window;
+            this.listDevices.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.listDevices.FullRowSelect = true;
+            this.listDevices.HideSelection = false;
+            this.listDevices.Location = new System.Drawing.Point(2, 17);
+            this.listDevices.Margin = new System.Windows.Forms.Padding(2);
+            this.listDevices.MultiSelect = false;
+            this.listDevices.Name = "listDevices";
+            this.listDevices.Size = new System.Drawing.Size(194, 300);
+            this.listDevices.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.listDevices.TabIndex = 12;
+            this.listDevices.TileSize = new System.Drawing.Size(238, 40);
+            this.listDevices.UseCompatibleStateImageBehavior = false;
+            this.listDevices.View = System.Windows.Forms.View.Tile;
+            this.listDevices.SelectedIndexChanged += new System.EventHandler(this.listDevices_SelectedIndexChanged_1);
+            // 
+            // label4
+            // 
+            this.label4.Location = new System.Drawing.Point(2, 2);
+            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(133, 20);
+            this.label4.TabIndex = 13;
+            this.label4.Text = "Connected Devices";
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.checkEnableAsCommunicationsOnStartup);
+            this.groupBox1.Controls.Add(this.checkEnableAsMultimediaOnStartup);
+            this.groupBox1.Controls.Add(this.checkCustomName);
+            this.groupBox1.Controls.Add(this.pictureModded);
+            this.groupBox1.Controls.Add(this.textCustomName);
+            this.groupBox1.Controls.Add(this.label12);
+            this.groupBox1.Controls.Add(this.checkHideDevice);
+            this.groupBox1.Controls.Add(this.label13);
+            this.groupBox1.Controls.Add(this.label14);
+            this.groupBox1.Controls.Add(this.label15);
+            this.groupBox1.Controls.Add(this.buttonRemove);
+            this.groupBox1.Controls.Add(this.buttonSave);
+            this.groupBox1.Controls.Add(this.trackBrightness);
+            this.groupBox1.Controls.Add(this.trackSaturation);
+            this.groupBox1.Controls.Add(this.trackHue);
+            this.groupBox1.Location = new System.Drawing.Point(200, 2);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
+            this.groupBox1.Size = new System.Drawing.Size(321, 279);
+            this.groupBox1.TabIndex = 14;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Selected Device Settings";
+            // 
+            // checkEnableAsCommunicationsOnStartup
+            // 
+            this.checkEnableAsCommunicationsOnStartup.Location = new System.Drawing.Point(14, 184);
+            this.checkEnableAsCommunicationsOnStartup.Margin = new System.Windows.Forms.Padding(2);
+            this.checkEnableAsCommunicationsOnStartup.Name = "checkEnableAsCommunicationsOnStartup";
+            this.checkEnableAsCommunicationsOnStartup.Size = new System.Drawing.Size(285, 16);
+            this.checkEnableAsCommunicationsOnStartup.TabIndex = 28;
+            this.checkEnableAsCommunicationsOnStartup.Text = "Enable as communications device on startup";
+            this.checkEnableAsCommunicationsOnStartup.UseVisualStyleBackColor = true;
+            // 
+            // checkEnableAsMultimediaOnStartup
+            // 
+            this.checkEnableAsMultimediaOnStartup.Location = new System.Drawing.Point(14, 164);
+            this.checkEnableAsMultimediaOnStartup.Margin = new System.Windows.Forms.Padding(2);
+            this.checkEnableAsMultimediaOnStartup.Name = "checkEnableAsMultimediaOnStartup";
+            this.checkEnableAsMultimediaOnStartup.Size = new System.Drawing.Size(263, 16);
+            this.checkEnableAsMultimediaOnStartup.TabIndex = 27;
+            this.checkEnableAsMultimediaOnStartup.Text = "Enable as multimedia device on startup";
+            this.checkEnableAsMultimediaOnStartup.UseVisualStyleBackColor = true;
+            // 
+            // checkCustomName
+            // 
+            this.checkCustomName.Location = new System.Drawing.Point(14, 109);
+            this.checkCustomName.Margin = new System.Windows.Forms.Padding(2);
+            this.checkCustomName.Name = "checkCustomName";
+            this.checkCustomName.Size = new System.Drawing.Size(149, 18);
+            this.checkCustomName.TabIndex = 3;
+            this.checkCustomName.Text = "Customize display name";
+            this.checkCustomName.UseVisualStyleBackColor = true;
+            this.checkCustomName.CheckedChanged += new System.EventHandler(this.checkCustomName_CheckedChanged_1);
+            // 
+            // pictureModded
+            // 
+            this.pictureModded.Location = new System.Drawing.Point(288, 15);
+            this.pictureModded.Margin = new System.Windows.Forms.Padding(2);
+            this.pictureModded.Name = "pictureModded";
+            this.pictureModded.Size = new System.Drawing.Size(24, 24);
+            this.pictureModded.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
+            this.pictureModded.TabIndex = 20;
+            this.pictureModded.TabStop = false;
+            // 
+            // textCustomName
+            // 
+            this.textCustomName.Enabled = false;
+            this.textCustomName.Location = new System.Drawing.Point(14, 131);
+            this.textCustomName.Margin = new System.Windows.Forms.Padding(2);
+            this.textCustomName.Name = "textCustomName";
+            this.textCustomName.Size = new System.Drawing.Size(190, 20);
+            this.textCustomName.TabIndex = 4;
+            // 
+            // label12
+            // 
+            this.label12.Location = new System.Drawing.Point(233, 19);
+            this.label12.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(66, 17);
+            this.label12.TabIndex = 26;
+            this.label12.Text = "Tray Icon Color";
+            // 
+            // checkHideDevice
+            // 
+            this.checkHideDevice.Location = new System.Drawing.Point(4, 255);
+            this.checkHideDevice.Margin = new System.Windows.Forms.Padding(2);
+            this.checkHideDevice.Name = "checkHideDevice";
+            this.checkHideDevice.Size = new System.Drawing.Size(177, 16);
+            this.checkHideDevice.TabIndex = 5;
+            this.checkHideDevice.Text = "Hide device from switch list";
+            this.checkHideDevice.UseVisualStyleBackColor = true;
+            // 
+            // label13
+            // 
+            this.label13.Location = new System.Drawing.Point(50, 30);
+            this.label13.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(27, 20);
+            this.label13.TabIndex = 16;
+            this.label13.Text = "Hue";
+            // 
+            // label14
+            // 
+            this.label14.Location = new System.Drawing.Point(21, 50);
+            this.label14.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(56, 18);
+            this.label14.TabIndex = 19;
+            this.label14.Text = "Saturation";
+            // 
+            // label15
+            // 
+            this.label15.Location = new System.Drawing.Point(20, 71);
+            this.label15.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(57, 14);
+            this.label15.TabIndex = 21;
+            this.label15.Text = "Brightness";
+            // 
+            // buttonRemove
+            // 
+            this.buttonRemove.Location = new System.Drawing.Point(108, 207);
+            this.buttonRemove.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonRemove.Name = "buttonRemove";
+            this.buttonRemove.Size = new System.Drawing.Size(100, 33);
+            this.buttonRemove.TabIndex = 6;
+            this.buttonRemove.Text = "Remove Settings";
+            this.buttonRemove.UseVisualStyleBackColor = true;
+            this.buttonRemove.Click += new System.EventHandler(this.buttonRemove_Click);
+            // 
+            // buttonSave
+            // 
+            this.buttonSave.Location = new System.Drawing.Point(212, 207);
+            this.buttonSave.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonSave.Name = "buttonSave";
+            this.buttonSave.Size = new System.Drawing.Size(100, 33);
+            this.buttonSave.TabIndex = 7;
+            this.buttonSave.Text = "Save Settings";
+            this.buttonSave.UseVisualStyleBackColor = true;
+            this.buttonSave.Click += new System.EventHandler(this.buttonSave_Click);
+            // 
+            // trackBrightness
+            // 
+            this.trackBrightness.BackColor = System.Drawing.SystemColors.Window;
+            this.trackBrightness.Location = new System.Drawing.Point(70, 70);
+            this.trackBrightness.Margin = new System.Windows.Forms.Padding(2);
+            this.trackBrightness.Maximum = 60;
+            this.trackBrightness.Name = "trackBrightness";
+            this.trackBrightness.Size = new System.Drawing.Size(131, 45);
+            this.trackBrightness.TabIndex = 2;
+            this.trackBrightness.TickStyle = System.Windows.Forms.TickStyle.None;
+            this.trackBrightness.Scroll += new System.EventHandler(this.trackBrightness_Scroll);
+            // 
+            // trackSaturation
+            // 
+            this.trackSaturation.BackColor = System.Drawing.SystemColors.Window;
+            this.trackSaturation.Location = new System.Drawing.Point(70, 49);
+            this.trackSaturation.Margin = new System.Windows.Forms.Padding(2);
+            this.trackSaturation.Maximum = 100;
+            this.trackSaturation.Name = "trackSaturation";
+            this.trackSaturation.Size = new System.Drawing.Size(131, 45);
+            this.trackSaturation.TabIndex = 1;
+            this.trackSaturation.TickStyle = System.Windows.Forms.TickStyle.None;
+            this.trackSaturation.Scroll += new System.EventHandler(this.trackSaturation_Scroll);
+            // 
+            // trackHue
+            // 
+            this.trackHue.BackColor = System.Drawing.SystemColors.Window;
+            this.trackHue.Location = new System.Drawing.Point(70, 29);
+            this.trackHue.Margin = new System.Windows.Forms.Padding(2);
+            this.trackHue.Maximum = 360;
+            this.trackHue.Name = "trackHue";
+            this.trackHue.Size = new System.Drawing.Size(131, 45);
+            this.trackHue.TabIndex = 22;
+            this.trackHue.TickStyle = System.Windows.Forms.TickStyle.None;
+            this.trackHue.Scroll += new System.EventHandler(this.trackHue_Scroll);
+            // 
+            // Devices
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.listDevices);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.groupBox1);
+            this.Name = "Devices";
+            this.Size = new System.Drawing.Size(528, 319);
+            this.Load += new System.EventHandler(this.Devices_Load);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureModded)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackHue)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Controls.CustomListView listDevices;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.CheckBox checkEnableAsCommunicationsOnStartup;
+        private System.Windows.Forms.CheckBox checkEnableAsMultimediaOnStartup;
+        private System.Windows.Forms.CheckBox checkCustomName;
+        private System.Windows.Forms.PictureBox pictureModded;
+        private System.Windows.Forms.TextBox textCustomName;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.CheckBox checkHideDevice;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.Button buttonRemove;
+        private System.Windows.Forms.Button buttonSave;
+        private System.Windows.Forms.TrackBar trackBrightness;
+        private System.Windows.Forms.TrackBar trackSaturation;
+        private System.Windows.Forms.TrackBar trackHue;
+    }
+}

--- a/Controls/Devices.cs
+++ b/Controls/Devices.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using AudioSwitch.CoreAudioApi;
+using AudioSwitch.Classes;
+using System.Collections;
+
+namespace AudioSwitch.Forms
+{
+    public partial class Devices : UserControl
+    {
+        public Devices()
+        {
+            InitializeComponent();
+        }
+
+        public void PostConstructor(EDataFlow dataFlow)
+        {
+            var devices = EDataFlow.eRender.Equals(dataFlow) ? DeviceRepository.FindPlayBackDevices() : DeviceRepository.FindCaptureDevices();
+            var cnt = 0;
+            foreach (var dev in devices)
+            {
+                var devID = dev.MMDevice.ID;
+                var lvitem = new ListViewItem { Text = dev.MMDevice.FriendlyName, ImageIndex = cnt, Tag = devID };
+
+                var devSettings = Program.settings.Device.Find(x => x.DeviceID == devID);
+                if (devSettings != null)
+                {
+                    lvitem.Font = new Font(lvitem.Font, FontStyle.Bold);
+
+                    if (devSettings.HideFromList)
+                        lvitem.Font = new Font(lvitem.Font, FontStyle.Italic);
+                }
+
+                listDevices.LargeImageList.Images.Add(DeviceIcons.GetIcon(dev.MMDevice.IconPath));
+                listDevices.Items.Add(lvitem);
+                cnt++;
+            }
+        }
+
+
+        private void Devices_Load(object sender, EventArgs e)
+        {
+            pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
+
+            FormSwitcher.SetWindowTheme(listDevices.Handle, "explorer", null);
+
+            var tile = new Size(listDevices.ClientSize.Width - 18, (int)(listDevices.TileSize.Height * FormSwitcher.DpiFactor));
+            listDevices.TileSize = tile;
+            var size = new Size((int)(32 * FormSwitcher.DpiFactor), (int)(32 * FormSwitcher.DpiFactor));
+            listDevices.LargeImageList = new ImageList
+            {
+                ImageSize = size,
+                ColorDepth = ColorDepth.Depth32Bit
+            };
+
+
+        }
+
+        private void buttonRemove_Click(object sender, EventArgs e)
+        {
+            trackHue.Value = 0;
+            trackSaturation.Value = 0;
+            trackBrightness.Value = 0;
+            pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
+            checkHideDevice.Checked = false;
+            checkCustomName.Checked = false;
+            textCustomName.Enabled = false;
+            textCustomName.Clear();
+            checkEnableAsMultimediaOnStartup.Checked = false;
+            checkEnableAsCommunicationsOnStartup.Checked = false;
+
+            listDevices.SelectedItems[0].Font = new Font(listDevices.SelectedItems[0].Font, FontStyle.Regular);
+
+            var devSettings = Program.settings.Device.Find(x => x.DeviceID == (string)listDevices.SelectedItems[0].Tag);
+            if (devSettings != null)
+                Program.settings.Device.Remove(devSettings);
+        }
+
+        private void buttonSave_Click(object sender, EventArgs e)
+        {
+            if (listDevices.SelectedItems.Count == 0) return;
+
+            var devSettings = Program.settings.Device.Find(x => x.DeviceID == (string)listDevices.SelectedItems[0].Tag);
+
+            listDevices.SelectedItems[0].Font = new Font(listDevices.SelectedItems[0].Font,
+                                                         checkHideDevice.Checked ? FontStyle.Italic : FontStyle.Bold);
+            IEnumerable<ListViewItem> lv = listDevices.Items.Cast<ListViewItem>();
+
+            if (checkEnableAsMultimediaOnStartup.Checked)
+            {
+                foreach(var item in lv) { 
+                    var settings = Program.settings.Device.Find(x => x.DeviceID == (string)item.Tag);
+                    if (settings != null)
+                    {
+                        settings.DefaultMultimediaDevice = false;
+                    }
+                }
+            }
+            if (checkEnableAsCommunicationsOnStartup.Checked)
+            {
+                foreach (var item in lv)
+                {
+                    var settings = Program.settings.Device.Find(x => x.DeviceID == (string)item.Tag);
+                    if (settings != null)
+                    {
+                        settings.DefaultCommunicationsDevice = false;
+                    }
+                }
+            }
+
+            if (devSettings != null)
+            {
+                devSettings.Brightness = trackBrightness.Value;
+                devSettings.Hue = trackHue.Value;
+                devSettings.Saturation = trackSaturation.Value;
+                devSettings.HideFromList = checkHideDevice.Checked;
+                devSettings.UseCustomName = checkCustomName.Checked;
+                devSettings.CustomName = textCustomName.Text;
+                devSettings.DefaultMultimediaDevice = checkEnableAsMultimediaOnStartup.Checked;
+                devSettings.DefaultCommunicationsDevice = checkEnableAsCommunicationsOnStartup.Checked;
+            }
+            else
+            {
+                devSettings = new Settings.CDevice
+                {
+                    DeviceID = (string)listDevices.SelectedItems[0].Tag,
+                    HideFromList = checkHideDevice.Checked,
+                    Brightness = trackBrightness.Value,
+                    Hue = trackHue.Value,
+                    Saturation = trackSaturation.Value,
+                    UseCustomName = checkCustomName.Checked,
+                    CustomName = textCustomName.Text,
+                    DefaultMultimediaDevice = checkEnableAsMultimediaOnStartup.Checked,
+                    DefaultCommunicationsDevice = checkEnableAsCommunicationsOnStartup.Checked
+
+                };
+                Program.settings.Device.Add(devSettings);
+            }
+
+        }
+
+
+        private void listDevices_SelectedIndexChanged_1(object sender, EventArgs e)
+        {
+            if (listDevices.SelectedItems.Count == 0) return;
+
+            var devSettings = Program.settings.Device.Find(x => x.DeviceID == (string)listDevices.SelectedItems[0].Tag);
+            if (devSettings == null)
+            {
+                trackBrightness.Value = 0;
+                trackHue.Value = 0;
+                trackSaturation.Value = 0;
+                pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
+                checkHideDevice.Checked = false;
+                checkCustomName.Checked = false;
+                textCustomName.Enabled = false;
+                textCustomName.Clear();
+                checkEnableAsMultimediaOnStartup.Checked = false;
+                checkEnableAsCommunicationsOnStartup.Checked = false;
+
+                return;
+            }
+
+            trackBrightness.Value = devSettings.Brightness;
+            trackHue.Value = devSettings.Hue;
+            trackSaturation.Value = devSettings.Saturation;
+
+            pictureModded.Image?.Dispose();
+            pictureModded.Image = DeviceIcons.ChangeColors(new Bitmap(Properties.Resources._66_100_highDPI), trackHue.Value, trackSaturation.Value / 100f, trackBrightness.Value / 100f);
+            checkHideDevice.Checked = devSettings.HideFromList;
+
+            checkCustomName.Checked = devSettings.UseCustomName;
+            textCustomName.Text = devSettings.CustomName;
+            checkEnableAsMultimediaOnStartup.Checked = devSettings.DefaultMultimediaDevice;
+            checkEnableAsCommunicationsOnStartup.Checked = devSettings.DefaultCommunicationsDevice;
+        }
+
+        private void checkCustomName_CheckedChanged_1(object sender, EventArgs e)
+        {
+            textCustomName.Enabled = checkCustomName.Checked;
+
+        }
+
+        private void trackBarsHSB_Scroll()
+        {
+            pictureModded.Image?.Dispose();
+            pictureModded.Image = DeviceIcons.ChangeColors(new Bitmap(Properties.Resources._66_100_highDPI), trackHue.Value, trackSaturation.Value / 100f, trackBrightness.Value / 100f);
+        }
+
+        private void trackHue_Scroll(object sender, EventArgs e)
+        {
+            trackBarsHSB_Scroll();
+        }
+
+        private void trackSaturation_Scroll(object sender, EventArgs e)
+        {
+            trackBarsHSB_Scroll();
+        }
+
+        private void trackBrightness_Scroll(object sender, EventArgs e)
+        {
+            trackBarsHSB_Scroll();
+        }
+    }
+}

--- a/Controls/Devices.cs
+++ b/Controls/Devices.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+﻿using AudioSwitch.Classes;
 using AudioSwitch.CoreAudioApi;
-using AudioSwitch.Classes;
-using System.Collections;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
 
 namespace AudioSwitch.Forms
 {
@@ -52,8 +47,16 @@ namespace AudioSwitch.Forms
             FormSwitcher.SetWindowTheme(listDevices.Handle, "explorer", null);
 
             var tile = new Size(listDevices.ClientSize.Width - 18, (int)(listDevices.TileSize.Height * FormSwitcher.DpiFactor));
+            if(tile.Width < 1 || tile.Height < 1)
+            {
+                tile = new Size(15, 15);
+            }
             listDevices.TileSize = tile;
             var size = new Size((int)(32 * FormSwitcher.DpiFactor), (int)(32 * FormSwitcher.DpiFactor));
+            if (size.Width < 1 || size.Height < 1)
+            {
+                size = new Size(15, 15);
+            }
             listDevices.LargeImageList = new ImageList
             {
                 ImageSize = size,

--- a/Controls/Devices.resx
+++ b/Controls/Devices.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Forms/FormSettings.Designer.cs
+++ b/Forms/FormSettings.Designer.cs
@@ -31,8 +31,8 @@ namespace AudioSwitch.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.tabSettings = new System.Windows.Forms.TabControl();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.tabControl = new System.Windows.Forms.TabControl();
             this.tabGeneral = new System.Windows.Forms.TabPage();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.checkVolScroll = new System.Windows.Forms.CheckBox();
@@ -52,6 +52,7 @@ namespace AudioSwitch.Forms
             this.comboOSDSkin = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.checkCloseSelect = new System.Windows.Forms.CheckBox();
             this.comboDefMode = new System.Windows.Forms.ComboBox();
             this.checkQSShowOSD = new System.Windows.Forms.CheckBox();
             this.radioQuickSwitch = new System.Windows.Forms.RadioButton();
@@ -61,22 +62,8 @@ namespace AudioSwitch.Forms
             this.checkColorVU = new System.Windows.Forms.CheckBox();
             this.label6 = new System.Windows.Forms.Label();
             this.checkDefaultMultiAndComm = new System.Windows.Forms.CheckBox();
-            this.tabDevices = new System.Windows.Forms.TabPage();
-            this.listDevices = new AudioSwitch.Controls.CustomListView();
-            this.label2 = new System.Windows.Forms.Label();
-            this.groupDevice = new System.Windows.Forms.GroupBox();
-            this.checkCustomName = new System.Windows.Forms.CheckBox();
-            this.textCustomName = new System.Windows.Forms.TextBox();
-            this.label7 = new System.Windows.Forms.Label();
-            this.checkHideDevice = new System.Windows.Forms.CheckBox();
-            this.label9 = new System.Windows.Forms.Label();
-            this.label10 = new System.Windows.Forms.Label();
-            this.label11 = new System.Windows.Forms.Label();
-            this.buttonResetDevice = new System.Windows.Forms.Button();
-            this.buttonSaveDevice = new System.Windows.Forms.Button();
-            this.trackBrightness = new System.Windows.Forms.TrackBar();
-            this.trackSaturation = new System.Windows.Forms.TrackBar();
-            this.trackHue = new System.Windows.Forms.TrackBar();
+            this.tabPlaybackDevices = new System.Windows.Forms.TabPage();
+            this.tabRecordingDevices = new System.Windows.Forms.TabPage();
             this.tabHotkeys = new System.Windows.Forms.TabPage();
             this.gridHotkeys = new System.Windows.Forms.DataGridView();
             this.Function = new System.Windows.Forms.DataGridViewComboBoxColumn();
@@ -88,10 +75,10 @@ namespace AudioSwitch.Forms
             this.ShowOSD = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.HotKey = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.labelTips = new System.Windows.Forms.Label();
-            this.pictureModded = new System.Windows.Forms.PictureBox();
             this.buttonClose = new System.Windows.Forms.Button();
-            this.checkCloseSelect = new System.Windows.Forms.CheckBox();
-            this.tabSettings.SuspendLayout();
+            this.recordingDevices = new AudioSwitch.Forms.Devices();
+            this.playbackDevices = new AudioSwitch.Forms.Devices();
+            this.tabControl.SuspendLayout();
             this.tabGeneral.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.groupOSD.SuspendLayout();
@@ -99,28 +86,25 @@ namespace AudioSwitch.Forms
             ((System.ComponentModel.ISupportInitialize)(this.numTimeout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackTransparency)).BeginInit();
             this.groupBox2.SuspendLayout();
-            this.tabDevices.SuspendLayout();
-            this.groupDevice.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackHue)).BeginInit();
+            this.tabPlaybackDevices.SuspendLayout();
+            this.tabRecordingDevices.SuspendLayout();
             this.tabHotkeys.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.gridHotkeys)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureModded)).BeginInit();
             this.SuspendLayout();
             // 
-            // tabSettings
+            // tabControl
             // 
-            this.tabSettings.Controls.Add(this.tabGeneral);
-            this.tabSettings.Controls.Add(this.tabDevices);
-            this.tabSettings.Controls.Add(this.tabHotkeys);
-            this.tabSettings.HotTrack = true;
-            this.tabSettings.Location = new System.Drawing.Point(2, 3);
-            this.tabSettings.Margin = new System.Windows.Forms.Padding(2);
-            this.tabSettings.Name = "tabSettings";
-            this.tabSettings.SelectedIndex = 0;
-            this.tabSettings.Size = new System.Drawing.Size(536, 353);
-            this.tabSettings.TabIndex = 0;
+            this.tabControl.Controls.Add(this.tabGeneral);
+            this.tabControl.Controls.Add(this.tabPlaybackDevices);
+            this.tabControl.Controls.Add(this.tabRecordingDevices);
+            this.tabControl.Controls.Add(this.tabHotkeys);
+            this.tabControl.HotTrack = true;
+            this.tabControl.Location = new System.Drawing.Point(2, 3);
+            this.tabControl.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControl.Name = "tabControl";
+            this.tabControl.SelectedIndex = 0;
+            this.tabControl.Size = new System.Drawing.Size(536, 376);
+            this.tabControl.TabIndex = 0;
             // 
             // tabGeneral
             // 
@@ -131,7 +115,7 @@ namespace AudioSwitch.Forms
             this.tabGeneral.Location = new System.Drawing.Point(4, 22);
             this.tabGeneral.Margin = new System.Windows.Forms.Padding(2);
             this.tabGeneral.Name = "tabGeneral";
-            this.tabGeneral.Size = new System.Drawing.Size(528, 327);
+            this.tabGeneral.Size = new System.Drawing.Size(528, 350);
             this.tabGeneral.TabIndex = 2;
             this.tabGeneral.Text = "General";
             this.tabGeneral.UseVisualStyleBackColor = true;
@@ -393,6 +377,16 @@ namespace AudioSwitch.Forms
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "General Behavior";
             // 
+            // checkCloseSelect
+            // 
+            this.checkCloseSelect.Location = new System.Drawing.Point(12, 121);
+            this.checkCloseSelect.Margin = new System.Windows.Forms.Padding(2);
+            this.checkCloseSelect.Name = "checkCloseSelect";
+            this.checkCloseSelect.Size = new System.Drawing.Size(186, 24);
+            this.checkCloseSelect.TabIndex = 26;
+            this.checkCloseSelect.Text = "Close menu after selecting device";
+            this.checkCloseSelect.UseVisualStyleBackColor = true;
+            // 
             // comboDefMode
             // 
             this.comboDefMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -488,197 +482,28 @@ namespace AudioSwitch.Forms
             this.checkDefaultMultiAndComm.UseVisualStyleBackColor = true;
             this.checkDefaultMultiAndComm.CheckedChanged += new System.EventHandler(this.checkDefaultMultiAndComm_CheckedChanged);
             // 
-            // tabDevices
+            // tabPlaybackDevices
             // 
-            this.tabDevices.Controls.Add(this.listDevices);
-            this.tabDevices.Controls.Add(this.label2);
-            this.tabDevices.Controls.Add(this.groupDevice);
-            this.tabDevices.Location = new System.Drawing.Point(4, 22);
-            this.tabDevices.Margin = new System.Windows.Forms.Padding(2);
-            this.tabDevices.Name = "tabDevices";
-            this.tabDevices.Padding = new System.Windows.Forms.Padding(2);
-            this.tabDevices.Size = new System.Drawing.Size(528, 327);
-            this.tabDevices.TabIndex = 1;
-            this.tabDevices.Text = "Devices";
-            this.tabDevices.UseVisualStyleBackColor = true;
-            this.tabDevices.Enter += new System.EventHandler(this.tabDevices_Enter);
+            this.tabPlaybackDevices.Controls.Add(this.playbackDevices);
+            this.tabPlaybackDevices.Location = new System.Drawing.Point(4, 22);
+            this.tabPlaybackDevices.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPlaybackDevices.Name = "tabPlaybackDevices";
+            this.tabPlaybackDevices.Padding = new System.Windows.Forms.Padding(2);
+            this.tabPlaybackDevices.Size = new System.Drawing.Size(528, 350);
+            this.tabPlaybackDevices.TabIndex = 1;
+            this.tabPlaybackDevices.Text = "Playback Devices";
+            this.tabPlaybackDevices.UseVisualStyleBackColor = true;
+            this.tabPlaybackDevices.Enter += new System.EventHandler(this.tabDevices_Enter);
             // 
-            // listDevices
+            // tabRecordingDevices
             // 
-            this.listDevices.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.listDevices.BackColor = System.Drawing.SystemColors.Window;
-            this.listDevices.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.listDevices.FullRowSelect = true;
-            this.listDevices.HideSelection = false;
-            this.listDevices.Location = new System.Drawing.Point(5, 20);
-            this.listDevices.Margin = new System.Windows.Forms.Padding(2);
-            this.listDevices.MultiSelect = false;
-            this.listDevices.Name = "listDevices";
-            this.listDevices.Size = new System.Drawing.Size(194, 300);
-            this.listDevices.Sorting = System.Windows.Forms.SortOrder.Ascending;
-            this.listDevices.TabIndex = 1;
-            this.listDevices.TileSize = new System.Drawing.Size(238, 40);
-            this.listDevices.UseCompatibleStateImageBehavior = false;
-            this.listDevices.View = System.Windows.Forms.View.Tile;
-            this.listDevices.SelectedIndexChanged += new System.EventHandler(this.listDevices_SelectedIndexChanged);
-            // 
-            // label2
-            // 
-            this.label2.Location = new System.Drawing.Point(5, 5);
-            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(133, 20);
-            this.label2.TabIndex = 8;
-            this.label2.Text = "Connected Devices";
-            // 
-            // groupDevice
-            // 
-            this.groupDevice.Controls.Add(this.checkCustomName);
-            this.groupDevice.Controls.Add(this.pictureModded);
-            this.groupDevice.Controls.Add(this.textCustomName);
-            this.groupDevice.Controls.Add(this.label7);
-            this.groupDevice.Controls.Add(this.checkHideDevice);
-            this.groupDevice.Controls.Add(this.label9);
-            this.groupDevice.Controls.Add(this.label10);
-            this.groupDevice.Controls.Add(this.label11);
-            this.groupDevice.Controls.Add(this.buttonResetDevice);
-            this.groupDevice.Controls.Add(this.buttonSaveDevice);
-            this.groupDevice.Controls.Add(this.trackBrightness);
-            this.groupDevice.Controls.Add(this.trackSaturation);
-            this.groupDevice.Controls.Add(this.trackHue);
-            this.groupDevice.Location = new System.Drawing.Point(203, 5);
-            this.groupDevice.Margin = new System.Windows.Forms.Padding(2);
-            this.groupDevice.Name = "groupDevice";
-            this.groupDevice.Padding = new System.Windows.Forms.Padding(2);
-            this.groupDevice.Size = new System.Drawing.Size(321, 246);
-            this.groupDevice.TabIndex = 8;
-            this.groupDevice.TabStop = false;
-            this.groupDevice.Text = "Selected Device Settings";
-            // 
-            // checkCustomName
-            // 
-            this.checkCustomName.Location = new System.Drawing.Point(14, 109);
-            this.checkCustomName.Margin = new System.Windows.Forms.Padding(2);
-            this.checkCustomName.Name = "checkCustomName";
-            this.checkCustomName.Size = new System.Drawing.Size(149, 18);
-            this.checkCustomName.TabIndex = 3;
-            this.checkCustomName.Text = "Customize display name";
-            this.checkCustomName.UseVisualStyleBackColor = true;
-            this.checkCustomName.CheckedChanged += new System.EventHandler(this.checkCustomName_CheckedChanged);
-            // 
-            // textCustomName
-            // 
-            this.textCustomName.Enabled = false;
-            this.textCustomName.Location = new System.Drawing.Point(14, 131);
-            this.textCustomName.Margin = new System.Windows.Forms.Padding(2);
-            this.textCustomName.Name = "textCustomName";
-            this.textCustomName.Size = new System.Drawing.Size(190, 20);
-            this.textCustomName.TabIndex = 4;
-            // 
-            // label7
-            // 
-            this.label7.Location = new System.Drawing.Point(233, 19);
-            this.label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(66, 17);
-            this.label7.TabIndex = 26;
-            this.label7.Text = "Tray Icon Color";
-            // 
-            // checkHideDevice
-            // 
-            this.checkHideDevice.Location = new System.Drawing.Point(4, 225);
-            this.checkHideDevice.Margin = new System.Windows.Forms.Padding(2);
-            this.checkHideDevice.Name = "checkHideDevice";
-            this.checkHideDevice.Size = new System.Drawing.Size(177, 16);
-            this.checkHideDevice.TabIndex = 5;
-            this.checkHideDevice.Text = "Hide device from switch list";
-            this.checkHideDevice.UseVisualStyleBackColor = true;
-            // 
-            // label9
-            // 
-            this.label9.Location = new System.Drawing.Point(50, 30);
-            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(27, 20);
-            this.label9.TabIndex = 16;
-            this.label9.Text = "Hue";
-            // 
-            // label10
-            // 
-            this.label10.Location = new System.Drawing.Point(21, 50);
-            this.label10.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(56, 18);
-            this.label10.TabIndex = 19;
-            this.label10.Text = "Saturation";
-            // 
-            // label11
-            // 
-            this.label11.Location = new System.Drawing.Point(20, 71);
-            this.label11.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(57, 14);
-            this.label11.TabIndex = 21;
-            this.label11.Text = "Brightness";
-            // 
-            // buttonResetDevice
-            // 
-            this.buttonResetDevice.Location = new System.Drawing.Point(108, 177);
-            this.buttonResetDevice.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonResetDevice.Name = "buttonResetDevice";
-            this.buttonResetDevice.Size = new System.Drawing.Size(100, 33);
-            this.buttonResetDevice.TabIndex = 6;
-            this.buttonResetDevice.Text = "Remove Settings";
-            this.buttonResetDevice.UseVisualStyleBackColor = true;
-            this.buttonResetDevice.Click += new System.EventHandler(this.buttonResetDevice_Click);
-            // 
-            // buttonSaveDevice
-            // 
-            this.buttonSaveDevice.Location = new System.Drawing.Point(212, 177);
-            this.buttonSaveDevice.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonSaveDevice.Name = "buttonSaveDevice";
-            this.buttonSaveDevice.Size = new System.Drawing.Size(100, 33);
-            this.buttonSaveDevice.TabIndex = 7;
-            this.buttonSaveDevice.Text = "Save Settings";
-            this.buttonSaveDevice.UseVisualStyleBackColor = true;
-            this.buttonSaveDevice.Click += new System.EventHandler(this.buttonSaveDevice_Click);
-            // 
-            // trackBrightness
-            // 
-            this.trackBrightness.BackColor = System.Drawing.SystemColors.Window;
-            this.trackBrightness.Location = new System.Drawing.Point(70, 70);
-            this.trackBrightness.Margin = new System.Windows.Forms.Padding(2);
-            this.trackBrightness.Maximum = 60;
-            this.trackBrightness.Name = "trackBrightness";
-            this.trackBrightness.Size = new System.Drawing.Size(131, 45);
-            this.trackBrightness.TabIndex = 2;
-            this.trackBrightness.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.trackBrightness.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
-            // 
-            // trackSaturation
-            // 
-            this.trackSaturation.BackColor = System.Drawing.SystemColors.Window;
-            this.trackSaturation.Location = new System.Drawing.Point(70, 49);
-            this.trackSaturation.Margin = new System.Windows.Forms.Padding(2);
-            this.trackSaturation.Maximum = 100;
-            this.trackSaturation.Name = "trackSaturation";
-            this.trackSaturation.Size = new System.Drawing.Size(131, 45);
-            this.trackSaturation.TabIndex = 1;
-            this.trackSaturation.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.trackSaturation.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
-            // 
-            // trackHue
-            // 
-            this.trackHue.BackColor = System.Drawing.SystemColors.Window;
-            this.trackHue.Location = new System.Drawing.Point(70, 29);
-            this.trackHue.Margin = new System.Windows.Forms.Padding(2);
-            this.trackHue.Maximum = 360;
-            this.trackHue.Name = "trackHue";
-            this.trackHue.Size = new System.Drawing.Size(131, 45);
-            this.trackHue.TabIndex = 22;
-            this.trackHue.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.trackHue.Scroll += new System.EventHandler(this.trackBarsHSB_Scroll);
+            this.tabRecordingDevices.Controls.Add(this.recordingDevices);
+            this.tabRecordingDevices.Location = new System.Drawing.Point(4, 22);
+            this.tabRecordingDevices.Name = "tabRecordingDevices";
+            this.tabRecordingDevices.Size = new System.Drawing.Size(528, 350);
+            this.tabRecordingDevices.TabIndex = 3;
+            this.tabRecordingDevices.Text = "Recording devices";
+            this.tabRecordingDevices.UseVisualStyleBackColor = true;
             // 
             // tabHotkeys
             // 
@@ -687,7 +512,7 @@ namespace AudioSwitch.Forms
             this.tabHotkeys.Margin = new System.Windows.Forms.Padding(2);
             this.tabHotkeys.Name = "tabHotkeys";
             this.tabHotkeys.Padding = new System.Windows.Forms.Padding(2);
-            this.tabHotkeys.Size = new System.Drawing.Size(528, 327);
+            this.tabHotkeys.Size = new System.Drawing.Size(528, 350);
             this.tabHotkeys.TabIndex = 0;
             this.tabHotkeys.Text = "Hot Keys";
             this.tabHotkeys.UseVisualStyleBackColor = true;
@@ -719,12 +544,12 @@ namespace AudioSwitch.Forms
             this.gridHotkeys.Name = "gridHotkeys";
             this.gridHotkeys.RowHeadersWidth = 25;
             this.gridHotkeys.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            this.gridHotkeys.RowsDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            this.gridHotkeys.RowsDefaultCellStyle = dataGridViewCellStyle2;
             this.gridHotkeys.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.gridHotkeys.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.gridHotkeys.Size = new System.Drawing.Size(520, 318);
@@ -792,23 +617,13 @@ namespace AudioSwitch.Forms
             // labelTips
             // 
             this.labelTips.ForeColor = System.Drawing.Color.Green;
-            this.labelTips.Location = new System.Drawing.Point(170, 3);
+            this.labelTips.Location = new System.Drawing.Point(322, 3);
             this.labelTips.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.labelTips.Name = "labelTips";
-            this.labelTips.Size = new System.Drawing.Size(362, 18);
+            this.labelTips.Size = new System.Drawing.Size(210, 18);
             this.labelTips.TabIndex = 7;
             this.labelTips.Text = "labelTips";
             this.labelTips.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // pictureModded
-            // 
-            this.pictureModded.Location = new System.Drawing.Point(288, 15);
-            this.pictureModded.Margin = new System.Windows.Forms.Padding(2);
-            this.pictureModded.Name = "pictureModded";
-            this.pictureModded.Size = new System.Drawing.Size(24, 24);
-            this.pictureModded.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureModded.TabIndex = 20;
-            this.pictureModded.TabStop = false;
             // 
             // buttonClose
             // 
@@ -821,24 +636,30 @@ namespace AudioSwitch.Forms
             this.buttonClose.UseVisualStyleBackColor = true;
             this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
             // 
-            // checkCloseSelect
+            // recordingDevices
             // 
-            this.checkCloseSelect.Location = new System.Drawing.Point(12, 121);
-            this.checkCloseSelect.Margin = new System.Windows.Forms.Padding(2);
-            this.checkCloseSelect.Name = "checkCloseSelect";
-            this.checkCloseSelect.Size = new System.Drawing.Size(186, 24);
-            this.checkCloseSelect.TabIndex = 26;
-            this.checkCloseSelect.Text = "Close menu after selecting device";
-            this.checkCloseSelect.UseVisualStyleBackColor = true;
+            this.recordingDevices.Location = new System.Drawing.Point(0, 4);
+            this.recordingDevices.Name = "recordingDevices";
+            this.recordingDevices.Size = new System.Drawing.Size(528, 319);
+            this.recordingDevices.TabIndex = 0;
+            this.recordingDevices.Load += new System.EventHandler(this.recordingDevices_Load);
+            // 
+            // playbackDevices
+            // 
+            this.playbackDevices.Location = new System.Drawing.Point(0, 4);
+            this.playbackDevices.Name = "playbackDevices";
+            this.playbackDevices.Size = new System.Drawing.Size(528, 319);
+            this.playbackDevices.TabIndex = 0;
+            this.playbackDevices.Load += new System.EventHandler(this.devices2_Load);
             // 
             // FormSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(537, 356);
+            this.ClientSize = new System.Drawing.Size(536, 377);
             this.Controls.Add(this.buttonClose);
             this.Controls.Add(this.labelTips);
-            this.Controls.Add(this.tabSettings);
+            this.Controls.Add(this.tabControl);
             this.DoubleBuffered = true;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Margin = new System.Windows.Forms.Padding(2);
@@ -852,7 +673,7 @@ namespace AudioSwitch.Forms
             this.TopMost = true;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSettings_FormClosing);
             this.Load += new System.EventHandler(this.FormSettings_Load);
-            this.tabSettings.ResumeLayout(false);
+            this.tabControl.ResumeLayout(false);
             this.tabGeneral.ResumeLayout(false);
             this.tabGeneral.PerformLayout();
             this.groupBox4.ResumeLayout(false);
@@ -863,38 +684,20 @@ namespace AudioSwitch.Forms
             ((System.ComponentModel.ISupportInitialize)(this.trackTransparency)).EndInit();
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();
-            this.tabDevices.ResumeLayout(false);
-            this.groupDevice.ResumeLayout(false);
-            this.groupDevice.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBrightness)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackSaturation)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackHue)).EndInit();
+            this.tabPlaybackDevices.ResumeLayout(false);
+            this.tabRecordingDevices.ResumeLayout(false);
             this.tabHotkeys.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.gridHotkeys)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureModded)).EndInit();
             this.ResumeLayout(false);
 
         }
 
         #endregion
 
-        private System.Windows.Forms.TabControl tabSettings;
+        private System.Windows.Forms.TabControl tabControl;
         private System.Windows.Forms.TabPage tabHotkeys;
-        private System.Windows.Forms.TabPage tabDevices;
+        private System.Windows.Forms.TabPage tabPlaybackDevices;
         private System.Windows.Forms.DataGridView gridHotkeys;
-        private Controls.CustomListView listDevices;
-        private System.Windows.Forms.GroupBox groupDevice;
-        private System.Windows.Forms.CheckBox checkHideDevice;
-        private System.Windows.Forms.Label label9;
-        private System.Windows.Forms.Label label10;
-        private System.Windows.Forms.Label label11;
-        private System.Windows.Forms.Button buttonResetDevice;
-        private System.Windows.Forms.Button buttonSaveDevice;
-        private System.Windows.Forms.TrackBar trackBrightness;
-        private System.Windows.Forms.TrackBar trackSaturation;
-        private System.Windows.Forms.TrackBar trackHue;
-        private System.Windows.Forms.PictureBox pictureModded;
-        private System.Windows.Forms.Label label7;
         private System.Windows.Forms.TabPage tabGeneral;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.Label label6;
@@ -912,7 +715,6 @@ namespace AudioSwitch.Forms
         private System.Windows.Forms.Label labelVersion;
         private System.Windows.Forms.ComboBox comboOSDSkin;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label label2;
         private System.Windows.Forms.CheckBox checkColorVU;
         private System.Windows.Forms.DataGridViewComboBoxColumn Function;
         private System.Windows.Forms.DataGridViewCheckBoxColumn Control;
@@ -928,14 +730,15 @@ namespace AudioSwitch.Forms
         private System.Windows.Forms.RadioButton radioQuickSwitch;
         private System.Windows.Forms.RadioButton radioAlwaysMenu;
         private System.Windows.Forms.CheckBox checkQSShowOSD;
-        private System.Windows.Forms.CheckBox checkCustomName;
-        private System.Windows.Forms.TextBox textCustomName;
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.TrackBar trackTransparency;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.NumericUpDown numTimeout;
         private System.Windows.Forms.CheckBox checkCustomOSD;
         private System.Windows.Forms.CheckBox checkCloseSelect;
+        private System.Windows.Forms.TabPage tabRecordingDevices;
         private System.Windows.Forms.Button buttonClose;
+        private Devices playbackDevices;
+        private Devices recordingDevices;
     }
 }

--- a/Forms/FormSettings.Designer.cs
+++ b/Forms/FormSettings.Designer.cs
@@ -31,7 +31,7 @@ namespace AudioSwitch.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             this.tabControl = new System.Windows.Forms.TabControl();
             this.tabGeneral = new System.Windows.Forms.TabPage();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
@@ -63,7 +63,9 @@ namespace AudioSwitch.Forms
             this.label6 = new System.Windows.Forms.Label();
             this.checkDefaultMultiAndComm = new System.Windows.Forms.CheckBox();
             this.tabPlaybackDevices = new System.Windows.Forms.TabPage();
+            this.playbackDevices = new AudioSwitch.Forms.Devices();
             this.tabRecordingDevices = new System.Windows.Forms.TabPage();
+            this.recordingDevices = new AudioSwitch.Forms.Devices();
             this.tabHotkeys = new System.Windows.Forms.TabPage();
             this.gridHotkeys = new System.Windows.Forms.DataGridView();
             this.Function = new System.Windows.Forms.DataGridViewComboBoxColumn();
@@ -76,8 +78,6 @@ namespace AudioSwitch.Forms
             this.HotKey = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.labelTips = new System.Windows.Forms.Label();
             this.buttonClose = new System.Windows.Forms.Button();
-            this.recordingDevices = new AudioSwitch.Forms.Devices();
-            this.playbackDevices = new AudioSwitch.Forms.Devices();
             this.tabControl.SuspendLayout();
             this.tabGeneral.SuspendLayout();
             this.groupBox4.SuspendLayout();
@@ -495,6 +495,14 @@ namespace AudioSwitch.Forms
             this.tabPlaybackDevices.UseVisualStyleBackColor = true;
             this.tabPlaybackDevices.Enter += new System.EventHandler(this.tabDevices_Enter);
             // 
+            // playbackDevices
+            // 
+            this.playbackDevices.Location = new System.Drawing.Point(0, 4);
+            this.playbackDevices.Name = "playbackDevices";
+            this.playbackDevices.Size = new System.Drawing.Size(528, 319);
+            this.playbackDevices.TabIndex = 0;
+            this.playbackDevices.Load += new System.EventHandler(this.playbackDevices_Load);
+            // 
             // tabRecordingDevices
             // 
             this.tabRecordingDevices.Controls.Add(this.recordingDevices);
@@ -504,6 +512,14 @@ namespace AudioSwitch.Forms
             this.tabRecordingDevices.TabIndex = 3;
             this.tabRecordingDevices.Text = "Recording devices";
             this.tabRecordingDevices.UseVisualStyleBackColor = true;
+            // 
+            // recordingDevices
+            // 
+            this.recordingDevices.Location = new System.Drawing.Point(0, 4);
+            this.recordingDevices.Name = "recordingDevices";
+            this.recordingDevices.Size = new System.Drawing.Size(528, 319);
+            this.recordingDevices.TabIndex = 0;
+            this.recordingDevices.Load += new System.EventHandler(this.recordingDevices_Load);
             // 
             // tabHotkeys
             // 
@@ -544,12 +560,12 @@ namespace AudioSwitch.Forms
             this.gridHotkeys.Name = "gridHotkeys";
             this.gridHotkeys.RowHeadersWidth = 25;
             this.gridHotkeys.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            this.gridHotkeys.RowsDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(186)));
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            this.gridHotkeys.RowsDefaultCellStyle = dataGridViewCellStyle1;
             this.gridHotkeys.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.gridHotkeys.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.gridHotkeys.Size = new System.Drawing.Size(520, 318);
@@ -635,22 +651,6 @@ namespace AudioSwitch.Forms
             this.buttonClose.Text = "Close";
             this.buttonClose.UseVisualStyleBackColor = true;
             this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
-            // 
-            // recordingDevices
-            // 
-            this.recordingDevices.Location = new System.Drawing.Point(0, 4);
-            this.recordingDevices.Name = "recordingDevices";
-            this.recordingDevices.Size = new System.Drawing.Size(528, 319);
-            this.recordingDevices.TabIndex = 0;
-            this.recordingDevices.Load += new System.EventHandler(this.recordingDevices_Load);
-            // 
-            // playbackDevices
-            // 
-            this.playbackDevices.Location = new System.Drawing.Point(0, 4);
-            this.playbackDevices.Name = "playbackDevices";
-            this.playbackDevices.Size = new System.Drawing.Size(528, 319);
-            this.playbackDevices.TabIndex = 0;
-            this.playbackDevices.Load += new System.EventHandler(this.devices2_Load);
             // 
             // FormSettings
             // 

--- a/Forms/FormSettings.cs
+++ b/Forms/FormSettings.cs
@@ -255,15 +255,15 @@ namespace AudioSwitch.Forms
         }
 
 
-
-        private void devices2_Load(object sender, EventArgs e)
-        {
-            playbackDevices.PostConstructor(EDataFlow.eRender);
-        }
-
         private void recordingDevices_Load(object sender, EventArgs e)
         {
             recordingDevices.PostConstructor(EDataFlow.eCapture);
+        }
+
+        private void playbackDevices_Load(object sender, EventArgs e)
+        {
+            playbackDevices.PostConstructor(EDataFlow.eRender);
+
         }
     }
 }

--- a/Forms/FormSettings.cs
+++ b/Forms/FormSettings.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Windows.Forms;
 using AudioSwitch.Classes;
 using AudioSwitch.CoreAudioApi;
+using System.Collections.Generic;
 
 namespace AudioSwitch.Forms
 {
@@ -16,16 +17,8 @@ namespace AudioSwitch.Forms
         {
             InitializeComponent();
 
-            FormSwitcher.SetWindowTheme(listDevices.Handle, "explorer", null);
-            var tile = new Size(listDevices.ClientSize.Width - 18, (int)(listDevices.TileSize.Height * FormSwitcher.DpiFactor));
-            listDevices.TileSize = tile;
 
-            var size = new Size((int)(32 * FormSwitcher.DpiFactor), (int)(32 * FormSwitcher.DpiFactor));
-            listDevices.LargeImageList = new ImageList
-            {
-                ImageSize = size,
-                ColorDepth = ColorDepth.Depth32Bit
-            };
+
 
             Function.DataSource = Enum.GetNames(typeof(HotkeyFunction));
             Function.DataPropertyName = "HKFunction";
@@ -45,27 +38,7 @@ namespace AudioSwitch.Forms
 
         private void FormSettings_Load(object sender, EventArgs e)
         {
-            var devices = EndPoints.GetAllDeviceList();
-            var cnt = 0;
-            foreach (var dev in devices)
-            {
-                var devID = dev.Key.ID;
-                var lvitem = new ListViewItem { Text = dev.Key.FriendlyName, ImageIndex = cnt, Tag = devID };
 
-                var devSettings = Program.settings.Device.Find(x => x.DeviceID == devID);
-                if (devSettings != null)
-                {
-                    lvitem.Font = new Font(lvitem.Font, FontStyle.Bold);
-
-                    if (devSettings.HideFromList)
-                        lvitem.Font = new Font(lvitem.Font, FontStyle.Italic);
-                }
-
-                listDevices.LargeImageList.Images.Add(dev.Value);
-                listDevices.Items.Add(lvitem);
-                cnt++;
-            }
-            pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
 
             var OSDskins = Directory.GetDirectories(Program.Root + "Skins");
             foreach (var skinDir in OSDskins)
@@ -210,91 +183,19 @@ namespace AudioSwitch.Forms
 
         private void trackBarsHSB_Scroll(object sender, EventArgs e)
         {
-            pictureModded.Image?.Dispose();
-            pictureModded.Image = DeviceIcons.ChangeColors(new Bitmap(Properties.Resources._66_100_highDPI), trackHue.Value, trackSaturation.Value / 100f, trackBrightness.Value/100f);
         }
 
         private void buttonResetDevice_Click(object sender, EventArgs e)
         {
-            trackHue.Value = 0;
-            trackSaturation.Value = 0;
-            trackBrightness.Value = 0;
-            pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
-            checkHideDevice.Checked = false;
-            checkCustomName.Checked = false;
-            textCustomName.Enabled = false;
-            textCustomName.Clear();
 
-            listDevices.SelectedItems[0].Font = new Font(listDevices.SelectedItems[0].Font, FontStyle.Regular);
-
-            var devSettings = Program.settings.Device.Find(x => x.DeviceID == (string)listDevices.SelectedItems[0].Tag);
-            if (devSettings != null)
-                Program.settings.Device.Remove(devSettings);
         }
 
         private void buttonSaveDevice_Click(object sender, EventArgs e)
         {
-            if (listDevices.SelectedItems.Count == 0) return;
 
-            var devSettings = Program.settings.Device.Find(x => x.DeviceID == (string) listDevices.SelectedItems[0].Tag);
-
-            listDevices.SelectedItems[0].Font = new Font(listDevices.SelectedItems[0].Font,
-                                                         checkHideDevice.Checked ? FontStyle.Italic : FontStyle.Bold);
-
-            if (devSettings != null)
-            {
-                devSettings.Brightness = trackBrightness.Value;
-                devSettings.Hue = trackHue.Value;
-                devSettings.Saturation = trackSaturation.Value;
-                devSettings.HideFromList = checkHideDevice.Checked;
-                devSettings.UseCustomName = checkCustomName.Checked;
-                devSettings.CustomName = textCustomName.Text;
-            }
-            else
-            {
-                devSettings = new Settings.CDevice
-                    {
-                        DeviceID = (string) listDevices.SelectedItems[0].Tag,
-                        HideFromList = checkHideDevice.Checked,
-                        Brightness = trackBrightness.Value,
-                        Hue = trackHue.Value,
-                        Saturation = trackSaturation.Value,
-                        UseCustomName = checkCustomName.Checked,
-                        CustomName = textCustomName.Text
-                    };
-                Program.settings.Device.Add(devSettings);
-            }
         }
 
-        private void listDevices_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (listDevices.SelectedItems.Count == 0) return;
 
-            var devSettings = Program.settings.Device.Find(x => x.DeviceID == (string)listDevices.SelectedItems[0].Tag);
-            if (devSettings == null)
-            {
-                trackBrightness.Value = 0;
-                trackHue.Value = 0;
-                trackSaturation.Value = 0;
-                pictureModded.Image = new Bitmap(Properties.Resources._66_100_highDPI);
-                checkHideDevice.Checked = false;
-                checkCustomName.Checked = false;
-                textCustomName.Enabled = false;
-                textCustomName.Clear();
-                return;
-            }
-
-            trackBrightness.Value = devSettings.Brightness;
-            trackHue.Value = devSettings.Hue;
-            trackSaturation.Value = devSettings.Saturation;
-
-            pictureModded.Image?.Dispose();
-            pictureModded.Image = DeviceIcons.ChangeColors(new Bitmap(Properties.Resources._66_100_highDPI), trackHue.Value, trackSaturation.Value / 100f, trackBrightness.Value / 100f);
-            checkHideDevice.Checked = devSettings.HideFromList;
-
-            checkCustomName.Checked = devSettings.UseCustomName;
-            textCustomName.Text = devSettings.CustomName;
-        }
 
         private void comboOSDSkin_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -353,9 +254,16 @@ namespace AudioSwitch.Forms
             groupOSD.Enabled = checkCustomOSD.Checked;
         }
 
-        private void checkCustomName_CheckedChanged(object sender, EventArgs e)
+
+
+        private void devices2_Load(object sender, EventArgs e)
         {
-            textCustomName.Enabled = checkCustomName.Checked;
+            playbackDevices.PostConstructor(EDataFlow.eRender);
+        }
+
+        private void recordingDevices_Load(object sender, EventArgs e)
+        {
+            recordingDevices.PostConstructor(EDataFlow.eCapture);
         }
     }
 }


### PR DESCRIPTION
- Add options to set multimedia and communications device on startup: For each device,  you can select if a device should enabled as multimedia / communications device on startup.
- Split the playback and the recording devices into different tabs in the settings screen.